### PR TITLE
Fixed Call.WaitFor to not throw an exception on cancelling the wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Fixed Call.WaitFor to not throw exception
+
 ## [2.1.0] - 2019-07-29
 ### Added
 - Added Task API

--- a/signalwire-dotnet/Relay/Calling/Call.cs
+++ b/signalwire-dotnet/Relay/Calling/Call.cs
@@ -165,7 +165,12 @@ namespace SignalWire.Relay.Calling
             API.API.Client.OnDisconnected += disconnectedCallback;
             OnStateChange += stateChangeCallback;
 
-            Task.Delay(timeout.Value, cancelDelay.Token).Wait();
+            try
+            {
+                Task.Delay(timeout.Value, cancelDelay.Token).Wait();
+            }
+            catch { }
+
 
             OnStateChange -= stateChangeCallback;
             API.API.Client.OnDisconnected -= disconnectedCallback;


### PR DESCRIPTION
This can go out as a 2.1.1 SDK-specific hotfix