### PR TITLE
Remove messagedata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 ### Fixed
 - Fixed Call.WaitFor to not throw exception
+### Removed
+- MessageData from low level results
 
 ## [2.1.0] - 2019-07-29
 ### Added

--- a/signalwire-dotnet/Relay/Calling/LL_BeginResult.cs
+++ b/signalwire-dotnet/Relay/Calling/LL_BeginResult.cs
@@ -15,9 +15,6 @@ namespace SignalWire.Relay.Calling
         [JsonProperty("message", NullValueHandling = NullValueHandling.Ignore)]
         public string Message { get; set; }
 
-        [JsonProperty("message_data", NullValueHandling = NullValueHandling.Ignore)]
-        public JObject MessageData { get; set; }
-
         [JsonProperty("node_id", NullValueHandling = NullValueHandling.Ignore)]
         public string NodeID { get; set; }
 

--- a/signalwire-dotnet/Relay/Calling/LL_ConnectResult.cs
+++ b/signalwire-dotnet/Relay/Calling/LL_ConnectResult.cs
@@ -14,8 +14,5 @@ namespace SignalWire.Relay.Calling
 
         [JsonProperty("message", NullValueHandling = NullValueHandling.Ignore)]
         public string Message { get; set; }
-
-        [JsonProperty("message_data", NullValueHandling = NullValueHandling.Ignore)]
-        public JObject MessageData { get; set; }
     }
 }


### PR DESCRIPTION
Message data is subject to change causing this to throw an exception in some rarer cases right now, removing to allow time for discussion and documentation first.

Include hotfix with 2.1.1