### PR TITLE
Lock task array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Network data filtering
+- Fuzzy reconnect delay
+
 ## [2.3.0] - 2019-10-22
 ### Added
 - Agent in blade.connect

--- a/signalwire-dotnet/Relay/Blade/BladeLogging.cs
+++ b/signalwire-dotnet/Relay/Blade/BladeLogging.cs
@@ -59,7 +59,7 @@ namespace Blade
                 StackFrame frame = new StackFrame(frameOffset);
                 MethodBase method = frame.GetMethod();
                 Console.WriteLine("{0} [{1,11}] ({2}.{3}) {4}", DateTime.Now.ToString("yyyy/MM/dd HH:mm:ss.fff"), logLevel, method.DeclaringType.FullName, method.Name, formatter(state, exception));
-                if (LogLevel == LogLevel.Trace && exception != null)
+                if (exception != null)
                 {
                     Console.ForegroundColor = ConsoleColor.DarkCyan;
                     Console.WriteLine(exception.ToString());

--- a/signalwire-dotnet/Relay/Blade/Messages/ConnectParams.cs
+++ b/signalwire-dotnet/Relay/Blade/Messages/ConnectParams.cs
@@ -29,6 +29,12 @@ namespace Blade.Messages
             public bool RouteAdd { get; set; } = false;
             [JsonProperty("route_remove", Required = Required.Always)]
             public bool RouteRemove { get; set; } = false;
+            [JsonProperty("authority_data", Required = Required.Always)]
+            public bool AuthorityData { get; set; } = false;
+            [JsonProperty("authority_add", Required = Required.Always)]
+            public bool AuthorityAdd { get; set; } = false;
+            [JsonProperty("authority_remove", Required = Required.Always)]
+            public bool AuthorityRemove { get; set; } = false;
             [JsonProperty("filtered_protocols", Required = Required.Always)]
             public bool FilteredProtocols { get; set; } = false;
             [JsonProperty("protocols", Required = Required.Always)]

--- a/signalwire-dotnet/Relay/Blade/Messages/ConnectParams.cs
+++ b/signalwire-dotnet/Relay/Blade/Messages/ConnectParams.cs
@@ -11,7 +11,7 @@ namespace Blade.Messages
         {
             public const int MAJOR = 2;
             public const int MINOR = 4;
-            public const int REVISION = 0;
+            public const int REVISION = 1;
 
             [JsonProperty("major", Required = Required.Always)]
             public int Major { get; set; } = MAJOR;
@@ -19,6 +19,20 @@ namespace Blade.Messages
             public int Minor { get; set; } = MINOR;
             [JsonProperty("revision", Required = Required.Always)]
             public int Revision { get; set; } = REVISION;
+        }
+
+        public sealed class NetworkParam
+        {
+            [JsonProperty("route_data", Required = Required.Always)]
+            public bool RouteData { get; set; } = false;
+            [JsonProperty("route_add", Required = Required.Always)]
+            public bool RouteAdd { get; set; } = false;
+            [JsonProperty("route_remove", Required = Required.Always)]
+            public bool RouteRemove { get; set; } = false;
+            [JsonProperty("filtered_protocols", Required = Required.Always)]
+            public bool FilteredProtocols { get; set; } = false;
+            [JsonProperty("protocols", Required = Required.Always)]
+            public List<string> Protocols { get; } = new List<string>();
         }
 
         [JsonProperty("version", Required = Required.Always)]
@@ -30,5 +44,10 @@ namespace Blade.Messages
 
         [JsonProperty("agent", NullValueHandling = NullValueHandling.Ignore)]
         public string Agent { get; set; }
+        [JsonProperty("identity", NullValueHandling = NullValueHandling.Ignore)]
+        public string Identity { get; set; }
+
+        [JsonProperty("network", NullValueHandling = NullValueHandling.Ignore)]
+        public NetworkParam Network { get; set; } = null;
     }
 }

--- a/signalwire-dotnet/Relay/Blade/UpstreamSession.cs
+++ b/signalwire-dotnet/Relay/Blade/UpstreamSession.cs
@@ -185,6 +185,8 @@ namespace Blade
         public string NodeID { get; private set; }
         public string MasterNodeID { get; private set; }
 
+        public object UserData { get; set; }
+
         public Cache Cache { get; }
 
         #region Subscription Registry

--- a/signalwire-dotnet/Relay/Blade/UpstreamSession.cs
+++ b/signalwire-dotnet/Relay/Blade/UpstreamSession.cs
@@ -28,6 +28,8 @@ namespace Blade
             public TimeSpan ConnectDelay { get; set; } = TimeSpan.FromSeconds(5);
             public TimeSpan ConnectTimeout { get; set; } = TimeSpan.FromSeconds(5);
             public TimeSpan CloseTimeout { get; set; } = TimeSpan.FromSeconds(5);
+            public string AutoIdentity { get; set; } = null;
+            public ConnectParams.NetworkParam NetworkData { get; set; } = null;
         }
 
         private sealed class SessionProtocolMetrics
@@ -411,6 +413,8 @@ namespace Blade
             Request request = Request.Create("blade.connect", out Blade.Messages.ConnectParams param, OnBladeConnectResponse);
             if (SessionID != null) param.SessionID = SessionID;
             if (mOptions.Authentication != null) param.Authentication = JsonConvert.DeserializeObject(mOptions.Authentication);
+            if (mOptions.NetworkData != null) param.Network = mOptions.NetworkData;
+            if (mOptions.AutoIdentity != null) param.Identity = mOptions.AutoIdentity;
             param.Agent = agent;
             Send(request, true);
         }

--- a/signalwire-dotnet/Relay/Blade/UpstreamSession.cs
+++ b/signalwire-dotnet/Relay/Blade/UpstreamSession.cs
@@ -499,8 +499,11 @@ namespace Blade
 
             if (json.Length > mSendBuffer.Length) throw new IndexOutOfRangeException("Request is too large");
 
-            mLogger.LogDebug("Sending Request Frame: {0} for {1}", request.ID, request.Method);
-            mLogger.LogDebug(request.ToJSON(Formatting.Indented));
+            if (mLogger.IsEnabled(LogLevel.Debug))
+            {
+                mLogger.LogDebug("Sending Request Frame: {0} for {1}", request.ID, request.Method);
+                mLogger.LogDebug(request.ToJSON(Formatting.Indented));
+            }
 
             if (request.ResponseExpected && !mRequests.TryAdd(request.ID, request)) throw new ArgumentException("Request id already exists in pending requests");
 
@@ -538,8 +541,11 @@ namespace Blade
 
             if (json.Length > mSendBuffer.Length) throw new IndexOutOfRangeException("Response is too large");
 
-            mLogger.LogDebug("Sending Response Frame: {0}", response.ID);
-            mLogger.LogDebug(response.ToJSON(Formatting.Indented));
+            if (mLogger.IsEnabled(LogLevel.Debug))
+            {
+                mLogger.LogDebug("Sending Response Frame: {0}", response.ID);
+                mLogger.LogDebug(response.ToJSON(Formatting.Indented));
+            }
 
             mSendQueue.Enqueue(json);
 
@@ -663,8 +669,11 @@ namespace Blade
                 while (State == SessionState.Connecting) Thread.Sleep(1);
 
                 Request request = Request.Parse(obj);
-                mLogger.LogDebug("Received Request Frame: {0} for {1}", request.ID, request.Method);
-                mLogger.LogDebug(obj.ToString());
+                if (mLogger.IsEnabled(LogLevel.Debug))
+                {
+                    mLogger.LogDebug("Received Request Frame: {0} for {1}", request.ID, request.Method);
+                    mLogger.LogDebug(obj.ToString());
+                }
 
                 switch (request.Method)
                 {
@@ -748,8 +757,11 @@ namespace Blade
             else
             {
                 Response response = Response.Parse(obj);
-                mLogger.LogDebug("Received Response Frame: {0}", response.ID);
-                mLogger.LogDebug(obj.ToString());
+                if (mLogger.IsEnabled(LogLevel.Debug))
+                {
+                    mLogger.LogDebug("Received Response Frame: {0}", response.ID);
+                    mLogger.LogDebug(obj.ToString());
+                }
 
                 if (!mRequests.TryRemove(response.ID, out Request request))
                 {

--- a/signalwire-dotnet/Relay/Blade/UpstreamSession.cs
+++ b/signalwire-dotnet/Relay/Blade/UpstreamSession.cs
@@ -343,7 +343,10 @@ namespace Blade
                         System.Diagnostics.Debug.Assert(false, "Tasks did not finish, asserted to check what remains instead of hanging indefinately");
                     }
 
-                    mTasks.Clear();
+                    lock (mTasks)
+                    {
+                        mTasks.Clear();
+                    }
 
                     NodeID = null;
                     MasterNodeID = null;
@@ -359,7 +362,13 @@ namespace Blade
                     OnDisconnected?.Invoke(this);
                 }
 
-                int completedIndex = Task.WaitAny(mTasks.ToArray());
+                Task[] tasks = null;
+                lock (mTasks)
+                {
+                    tasks = mTasks.ToArray();
+                }
+
+                int completedIndex = Task.WaitAny(tasks);
                 if (completedIndex < 0) continue;
                 RemoveTask(mTasks[completedIndex]);
             }

--- a/signalwire-dotnet/Relay/Blade/UpstreamSession.cs
+++ b/signalwire-dotnet/Relay/Blade/UpstreamSession.cs
@@ -350,7 +350,9 @@ namespace Blade
 
                     mSocket.Dispose();
                     mSocket = null;
-                    mConnectAt = DateTime.Now.Add(mOptions.ConnectDelay);
+
+                    // Fuzzy reconnection logic by +- 10% of total delay
+                    mConnectAt = DateTime.Now.Add(TimeSpan.FromTicks(mOptions.ConnectDelay.Ticks + (mOptions.ConnectDelay.Ticks * (new Random().Next(-10, 10) / 100))));
 
                     State = SessionState.Offline;
 

--- a/signalwire-dotnet/Relay/Client.cs
+++ b/signalwire-dotnet/Relay/Client.cs
@@ -56,6 +56,7 @@ namespace SignalWire.Relay
             string host = null,
             string certificate = null,
             string agent = null,
+            ConnectParams.NetworkParam network = null,
             bool jwt = false,
             TimeSpan? connectDelay = null,
             TimeSpan? connectTimeout = null,
@@ -79,6 +80,7 @@ namespace SignalWire.Relay
                 Bootstrap = new Uri("wss://" + host),
                 Authentication = authentication,
                 Agent = agent,
+                NetworkData = network,
             };
             if (connectDelay.HasValue) options.ConnectDelay = connectDelay.Value;
             if (connectTimeout.HasValue) options.ConnectTimeout = connectTimeout.Value;
@@ -110,6 +112,8 @@ namespace SignalWire.Relay
         public TaskingAPI Tasking {  get { return mTaskingAPI; } }
 
         public MessagingAPI Messaging { get { return mMessagingAPI; } }
+
+        public object UserData { get; set; }
 
 
         public event ClientCallback OnReady;


### PR DESCRIPTION
Sighted a possible cause for the null entry in the intermediate tasks array that was not being seen in the original mTasks list during debugging.  Locked on array generation, needs staging and production testing to see if the rare issue goes away.  I was only able to catch this twice locally during some extensive load testing periods on switchblade over weeks of testing, very hard to reproduce.  Last indication is that service was up 3 weeks before it hit this issue in production.
