### PR TITLE
Multi-target net8.0, net9.0, and net10.0

### DIFF
--- a/src/SignalWire/SignalWire.csproj
+++ b/src/SignalWire/SignalWire.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <RootNamespace>SignalWire</RootNamespace>
     <AssemblyName>SignalWire</AssemblyName>
     <PackageId>SignalWire.Sdk</PackageId>

--- a/tests/SignalWire.Tests.csproj
+++ b/tests/SignalWire.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <RootNamespace>SignalWire.Tests</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
The SDK and test project now build against all three supported .NET versions. NuGet consumers automatically get the right TFM for their project. No API or behavior changes.

## Description

<!-- What does this PR do? Why is this change needed? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code cleanup / refactor

## Related Issues

<!-- Link any related issues: Fixes #123 or Relates to #456 -->

## Testing

<!-- How did you test your changes? -->

- [ ] Added/updated unit tests
- [ ] Tested manually
- [ ] Tested with live SignalWire credentials (if applicable)

## Checklist

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [ ] My code follows the project's style guidelines
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)
- [ ] All existing tests pass

## Additional Notes

<!-- Any other context about the PR -->
