### PR TITLE
deps: bump YamlDotNet 16.2.1 -> 18.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,16 @@ jobs:
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 
+      # The EMISSION gate compares this port's to_dict() output against the
+      # signalwire-python oracle (FunctionResult), which pulls fastapi via
+      # signalwire/__init__. Check it out so the EMISSION gate has its reference.
+      - name: Checkout signalwire-python (EMISSION oracle)
+        uses: actions/checkout@v5
+        with:
+          repository: signalwire/signalwire-python
+          path: signalwire-python
+          ref: main
+
       - name: Set up .NET SDKs (net8.0 / net9.0 / net10.0)
         # Host-side dotnet is consumed by scripts/enumerate_signatures.py
         # for the SIGNATURES gate. The TEST gate uses docker (see run-ci.sh).
@@ -59,6 +69,16 @@ jobs:
         run: |
           pip install -e porting-sdk/test_harness/mock_relay
           pip install -e porting-sdk/test_harness/mock_signalwire
+
+      # EMISSION needs `import signalwire` (the oracle). Install from the
+      # adjacent checkout only if not already importable.
+      - name: Install signalwire-python (EMISSION oracle) if not importable
+        run: |
+          if python -c "import signalwire.core.function_result" 2>/dev/null; then
+            echo "signalwire-python already importable; skipping install"
+          else
+            pip install ./signalwire-python
+          fi
 
       - name: Run CI gate script (TEST -> SIGNATURES -> DRIFT -> NO-CHEAT)
         working-directory: signalwire-dotnet

--- a/src/SignalWire/SignalWire.csproj
+++ b/src/SignalWire/SignalWire.csproj
@@ -33,7 +33,7 @@
   <ItemGroup>
     <!-- YamlDotNet is the .NET-idiomatic YAML library; used by POM
          to mirror Python's ``PromptObjectModel.from_yaml/to_yaml``. -->
-    <PackageReference Include="YamlDotNet" Version="16.2.1" />
+    <PackageReference Include="YamlDotNet" Version="18.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Change
- **`YamlDotNet` 16.2.1 → 18.0.0** (two majors; shipped runtime dep, used for POM YAML round-trip). **No code changes required** — the 17/18 breaking changes are confined to `ITypeInspector`/`TypeInspectorSkeleton` and `MergingParser` (unused by the POM); the `SerializerBuilder`/`DeserializerBuilder` fluent API, `NullNamingConvention.Instance`, `DisableAliases()`, and `Deserialize<object?>` shape are unchanged. The load-bearing `NullNamingConvention` + `DisableAliases` (byte-exact Python parity) are preserved.

## Verification
`bash scripts/run-ci.sh` (net8.0 + net9.0 runtimes installed locally): **all 6 gates PASS across net8/net9/net10.** Full suite 1175/1175 incl. POM YAML parity (byte-exact ToYaml + round-trip, 32/32) and **EMISSION 81/81 byte-identical to the Python to_dict() oracle** — confirming YamlDotNet 18 preserves the wire-exact YAML output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)