### PR TITLE
feat: full gate parity (FMT/LINT/DOC-AUDIT/SURFACE-DIFF/SKILL-CONTRACT) + idiomatic analyzer burndown

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,46 @@
+root = true
+
+# ---------------------------------------------------------------------------
+# signalwire-dotnet — formatting + analyzer policy.
+#
+# FMT gate: `dotnet format whitespace` (the whitespace/newline rules below).
+# LINT gate: a clean analyzer build (Directory.Build.props turns analyzers on
+# with TreatWarningsAsErrors). Per-rule severities below encode the cross-port
+# principle (locked 2026-06-16): every rule that is a genuinely useful standing
+# signal stays ON (error) and is burned to zero; a rule is set to `none` ONLY
+# when obeying it would change the SWAIG wire bytes / rename a wire token, or
+# when it is genuinely low-value here. Each `none` carries its rationale.
+# Type/shape idiom (Uri, IReadOnlyList, properties, naming) is NEVER a reason to
+# suppress — where it diverges from Python, the parity checker is taught the
+# equivalence (porting-sdk/type_aliases.yaml), not the code de-idiomatized.
+# ---------------------------------------------------------------------------
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+
+[*.cs]
+indent_size = 4
+
+# ── Analyzer rules turned OFF (with rationale) ─────────────────────────────
+# These are the ONLY suppressed rules. Everything else stays at its default
+# (error, via TreatWarningsAsErrors) and is burned to zero.
+
+# CA1308 "prefer ToUpperInvariant": KEPT ON globally (real locale signal); the
+# few wire-semantic lowercasing sites (lowercase hex token generation) are
+# suppressed INLINE at the site with rationale, not here.
+
+# CA1716 — identifiers should not match reserved language keywords (VB
+# `Event`/`Call`/etc.). `Event`, `Call`, `Action` are the idiomatic .NET type
+# names AND the cross-port concept names; VB-keyword interop is not a concern
+# for this SDK. Low-value here; renaming would churn the public surface for no
+# real benefit.
+dotnet_diagnostic.CA1716.severity = none
+
+# CA1724 — type name conflicts with a namespace. The few collisions are
+# intentional concept names shared across the cross-port surface; renaming
+# would diverge from the other ports' type names for no functional gain.
+dotnet_diagnostic.CA1724.severity = none

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,32 @@
+<Project>
+
+  <!--
+    Repo-wide build defaults. The LINT gate (scripts/run-ci.sh) builds
+    src/SignalWire with these on, so a warning is a build failure.
+
+    Governing principle (cross-port, locked 2026-06-16): language idiom drives
+    type/shape; every analyzer rule that is a genuinely useful standing signal
+    is ON and burned to zero (burndown cost is not a disqualifier). A rule is
+    turned OFF only when obeying it would change the SWAIG wire bytes or rename
+    a wire token, or when it is genuinely low-value for this codebase. Per-rule
+    severities + rationale live in .editorconfig.
+  -->
+
+  <!--
+    The analyzer bar applies ONLY to the shipped library (SignalWire.csproj) —
+    that is the public surface the LINT gate polices. Test/example/tool projects
+    (tests/, examples/, tools/, scripts/) carry intentionally loose code (audit
+    harnesses, corpus dumps) and would only fight the gate, so they are left at
+    the SDK defaults. Keyed off the project file name so the scoping is robust
+    regardless of path-separator quirks.
+  -->
+  <PropertyGroup Condition="'$(MSBuildProjectFile)' == 'SignalWire.csproj'">
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <AnalysisMode>All</AnalysisMode>
+    <!-- A lint violation fails the build → the LINT gate. -->
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+
+</Project>

--- a/port_signatures.json
+++ b/port_signatures.json
@@ -2952,15 +2952,15 @@
                 },
                 {
                   "name": "format",
-                  "type": "class:signalwire.swaig.record_format.RecordFormat",
+                  "type": "string",
                   "required": false,
-                  "default": "Wav"
+                  "default": "wav"
                 },
                 {
                   "name": "direction",
-                  "type": "class:signalwire.swaig.record_direction.RecordDirection",
+                  "type": "string",
                   "required": false,
-                  "default": "Both"
+                  "default": "both"
                 },
                 {
                   "name": "terminators",
@@ -3441,15 +3441,15 @@
                 },
                 {
                   "name": "direction",
-                  "type": "class:signalwire.swaig.tap_direction.TapDirection",
+                  "type": "string",
                   "required": false,
-                  "default": "Both"
+                  "default": "both"
                 },
                 {
                   "name": "codec",
-                  "type": "class:signalwire.swaig.codec.Codec",
+                  "type": "string",
                   "required": false,
-                  "default": "Pcmu"
+                  "default": "PCMU"
                 },
                 {
                   "name": "rtp_ptime",
@@ -7217,7 +7217,7 @@
                   "kind": "self"
                 },
                 {
-                  "name": "params_",
+                  "name": "parameters",
                   "type": "dict<string,any>",
                   "required": true
                 },
@@ -9002,7 +9002,7 @@
                   "kind": "self"
                 },
                 {
-                  "name": "params_",
+                  "name": "parameters",
                   "type": "dict<string,any>",
                   "required": true
                 },
@@ -9036,7 +9036,7 @@
                   "required": true
                 },
                 {
-                  "name": "params_",
+                  "name": "parameters",
                   "type": "optional<dict<string,any>>",
                   "required": false,
                   "default": null
@@ -9327,7 +9327,7 @@
                   "kind": "self"
                 },
                 {
-                  "name": "params_",
+                  "name": "parameters",
                   "type": "dict<string,any>",
                   "required": true
                 },
@@ -9398,7 +9398,7 @@
                   "required": true
                 },
                 {
-                  "name": "params_",
+                  "name": "parameters",
                   "type": "optional<dict<string,any>>",
                   "required": false,
                   "default": null
@@ -9506,7 +9506,7 @@
                   "required": true
                 },
                 {
-                  "name": "params_",
+                  "name": "parameters",
                   "type": "dict<string,any>",
                   "required": true
                 },
@@ -9572,7 +9572,7 @@
                   "required": true
                 },
                 {
-                  "name": "params_",
+                  "name": "parameters",
                   "type": "dict<string,any>",
                   "required": true
                 }
@@ -9630,7 +9630,7 @@
                   "kind": "self"
                 },
                 {
-                  "name": "params_",
+                  "name": "parameters",
                   "type": "optional<dict<string,any>>",
                   "required": false,
                   "default": null
@@ -11621,12 +11621,12 @@
                   "kind": "self"
                 },
                 {
-                  "name": "sid",
+                  "name": "id",
                   "type": "string",
                   "required": true
                 },
                 {
-                  "name": "kwargs",
+                  "name": "data",
                   "type": "dict<string,any>",
                   "required": true
                 },
@@ -11731,12 +11731,12 @@
                   "kind": "self"
                 },
                 {
-                  "name": "sid",
+                  "name": "id",
                   "type": "string",
                   "required": true
                 },
                 {
-                  "name": "kwargs",
+                  "name": "data",
                   "type": "dict<string,any>",
                   "required": true
                 },
@@ -12148,12 +12148,12 @@
                   "kind": "self"
                 },
                 {
-                  "name": "sid",
+                  "name": "id",
                   "type": "string",
                   "required": true
                 },
                 {
-                  "name": "kwargs",
+                  "name": "data",
                   "type": "dict<string,any>",
                   "required": true
                 },
@@ -12196,12 +12196,12 @@
                   "kind": "self"
                 },
                 {
-                  "name": "sid",
+                  "name": "id",
                   "type": "string",
                   "required": true
                 },
                 {
-                  "name": "kwargs",
+                  "name": "data",
                   "type": "dict<string,any>",
                   "required": true
                 },
@@ -12302,12 +12302,12 @@
                   "kind": "self"
                 },
                 {
-                  "name": "sid",
+                  "name": "id",
                   "type": "string",
                   "required": true
                 },
                 {
-                  "name": "kwargs",
+                  "name": "data",
                   "type": "dict<string,any>",
                   "required": true
                 },
@@ -12730,12 +12730,12 @@
                   "kind": "self"
                 },
                 {
-                  "name": "sid",
+                  "name": "id",
                   "type": "string",
                   "required": true
                 },
                 {
-                  "name": "kwargs",
+                  "name": "data",
                   "type": "dict<string,any>",
                   "required": true
                 },
@@ -14457,7 +14457,7 @@
                   "required": true
                 },
                 {
-                  "name": "kwargs",
+                  "name": "data",
                   "type": "dict<string,any>",
                   "required": true
                 },
@@ -14653,7 +14653,7 @@
                   "required": true
                 },
                 {
-                  "name": "kwargs",
+                  "name": "data",
                   "type": "dict<string,any>",
                   "required": true
                 },
@@ -15110,7 +15110,7 @@
                   "required": true
                 },
                 {
-                  "name": "kwargs",
+                  "name": "data",
                   "type": "dict<string,any>",
                   "required": true
                 },
@@ -15326,7 +15326,7 @@
                   "required": true
                 },
                 {
-                  "name": "kwargs",
+                  "name": "data",
                   "type": "dict<string,any>",
                   "required": true
                 },
@@ -15756,7 +15756,7 @@
                   "required": true
                 },
                 {
-                  "name": "kwargs",
+                  "name": "data",
                   "type": "dict<string,any>",
                   "required": true
                 },

--- a/port_surface.json
+++ b/port_surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_from": "signalwire-dotnet @ 3bda8411c8993b2494d2c97d7a4a26d4519aab4e",
+  "generated_from": "signalwire-dotnet @ cbb39e7bd89917ac84e25767963958c66a920292",
   "modules": {
     "signalwire.agent.agent_options": {
       "classes": {

--- a/scripts/emit-skills.sh
+++ b/scripts/emit-skills.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# emit-skills.sh — clean-stdout wrapper around the .NET SKILL-DUMP program
+# (tools/EmitSkills), the sibling of emit-corpus.sh for the SKILL-CONTRACT gate.
+#
+# It builds the EmitSkills console app, then runs the compiled binary directly
+# so that ONLY the skill-contract JSON object reaches stdout. The cross-port
+# differ (porting-sdk/scripts/diff_skill_contracts.py) parses that single object
+# from stdout, so all MSBuild build chatter is routed to stderr (same rationale
+# and host-or-docker fallback as emit-corpus.sh).
+#
+# Usage (from the signalwire-dotnet repo root):
+#   bash scripts/emit-skills.sh
+#   python3 .../diff_skill_contracts.py --dump-cmd 'bash scripts/emit-skills.sh' --port-repo .
+#
+# EmitSkills shells out to python3 to read the shared corpus
+# (porting-sdk/scripts/skill_contract_corpus.py); $PORTING_SDK is forwarded so
+# it resolves in CI (where porting-sdk is a workspace sibling, not ~/src).
+
+set -u
+set -o pipefail
+
+PORT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PROJ="tools/EmitSkills/EmitSkills.csproj"
+
+cd "$PORT_ROOT"
+
+dotnet_bin="$(command -v dotnet || true)"
+
+if [ -n "$dotnet_bin" ]; then
+    "$dotnet_bin" build "$PROJ" -c Release -v quiet 1>&2 || exit 1
+    dll="$(find tools/EmitSkills/bin -name EmitSkills.dll | head -1)"
+    if [ -z "$dll" ]; then
+        echo "emit-skills.sh: EmitSkills.dll not found after build" >&2
+        exit 1
+    fi
+    exec "$dotnet_bin" "$dll"
+else
+    exec docker run --rm \
+        --user "$(id -u):$(id -g)" \
+        -e HOME=/tmp \
+        -e PORTING_SDK="${PORTING_SDK:-}" \
+        -v "$PWD:/src" -w /src \
+        mcr.microsoft.com/dotnet/sdk:10.0 \
+        bash -c '
+            set -e
+            dotnet build '"$PROJ"' -c Release -v quiet 1>&2
+            dll=$(find tools/EmitSkills/bin -name EmitSkills.dll | head -1)
+            if [ -z "$dll" ]; then
+                echo "emit-skills.sh: EmitSkills.dll not found after build" >&2
+                exit 1
+            fi
+            dotnet "$dll"
+        '
+fi

--- a/scripts/enumerate_signatures.py
+++ b/scripts/enumerate_signatures.py
@@ -160,9 +160,11 @@ def translate_dotnet_type(t: str, aliases: dict[str, str], context: str) -> str:
         "System.Collections.Generic.List",
         "System.Collections.Generic.IList",
         "System.Collections.Generic.IReadOnlyList",
+        "System.Collections.Generic.IReadOnlyCollection",
         "System.Collections.Generic.IEnumerable",
         "System.Collections.Generic.ICollection",
         "System.Collections.Generic.IAsyncEnumerable",
+        "System.Collections.ObjectModel.ReadOnlyCollection",
         "System.Collections.Concurrent.ConcurrentQueue",
         "System.Collections.Concurrent.ConcurrentBag",
     ):

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -145,6 +145,9 @@ ensure_mock_relay() {
 
 cleanup_spawned() {
     local pid
+    # `${arr[@]}` on an empty array trips `set -u` on bash < 5.2; guard it so a
+    # clean exit (mocks already running → nothing spawned) doesn't error out.
+    [ ${#SPAWNED_PIDS[@]} -eq 0 ] && return 0
     for pid in "${SPAWNED_PIDS[@]}"; do
         if kill -0 "$pid" 2>/dev/null; then
             kill "$pid" 2>/dev/null || true

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -239,6 +239,47 @@ surface_fresh_gate() {
     return $rc
 }
 
+# Resolve a dotnet invocation: host dotnet if present, else the SDK docker image
+# (same host-or-docker shape as dotnet_test_per_framework). Echoes a command
+# prefix the caller runs as `$(dotnet_cmd) <args>`. Docker maps the repo at /src
+# as the host user with a writable HOME so MSBuild/NuGet caches work.
+dotnet_cmd() {
+    local bin
+    bin="$(command -v dotnet || true)"
+    if [ -n "$bin" ]; then
+        echo "$bin"
+    else
+        echo "docker run --rm --user $(id -u):$(id -g) -e HOME=/tmp -v $PWD:/src -w /src mcr.microsoft.com/dotnet/sdk:10.0 dotnet"
+    fi
+}
+
+# FMT gate: dotnet format whitespace (the house style — whitespace/newlines).
+# LOCAL ($CI unset) auto-fixes the tree; CI ($CI=true) verifies read-only and
+# FAILS on any unformatted file. Whitespace-scoped so it stays orthogonal to the
+# LINT gate (analyzers); a reformat is surface/emission-neutral.
+fmt_gate() {
+    local dn
+    dn="$(dotnet_cmd)"
+    if [ -n "${CI:-}" ]; then
+        $dn format whitespace SignalWire.sln --verify-no-changes
+    else
+        $dn format whitespace SignalWire.sln
+        if ! git diff --quiet 2>/dev/null; then
+            echo "    (FMT auto-applied whitespace formatting — review & stage)"
+        fi
+    fi
+}
+
+# LINT gate: a clean analyzer build. Directory.Build.props turns the curated
+# analyzer set on with TreatWarningsAsErrors across net8/9/10, so `dotnet build`
+# failing == a lint violation. Builds the src library only (analyzers run there;
+# tests/examples/tools are not the shipped surface).
+lint_gate() {
+    local dn
+    dn="$(dotnet_cmd)"
+    $dn build src/SignalWire/SignalWire.csproj -c Release --no-incremental
+}
+
 cd "$PORT_ROOT"
 
 echo "==> running CI gates for $PORT_NAME (porting-sdk at $PORTING_SDK_DIR)"
@@ -281,6 +322,41 @@ run_gate "NO-CHEAT" "audit_no_cheat_tests" \
 run_gate "EMISSION" "diff_port_emission vs python to_dict()" \
     python3 "$PORTING_SDK_DIR/scripts/diff_port_emission.py" \
         --dump-cmd "bash $PORT_ROOT/scripts/emit-corpus.sh"
+
+# Gate 7: FMT — dotnet format whitespace (local: auto-fix; CI: --verify).
+run_gate "FMT" "dotnet format whitespace (local: auto-fix; CI: --verify)" \
+    fmt_gate
+
+# Gate 8: LINT — clean analyzer build (Directory.Build.props: curated CA set,
+# TreatWarningsAsErrors). A build warning == a lint violation.
+run_gate "LINT" "dotnet build (analyzers, warnings-as-errors)" \
+    lint_gate
+
+# Gate 9: DOC-AUDIT — every symbol referenced in docs/examples resolves to a
+# real entry in port_surface.json (or is excused in DOC_AUDIT_IGNORE.md).
+run_gate "DOC-AUDIT" "audit_docs vs port_surface.json" \
+    python3 "$PORTING_SDK_DIR/scripts/audit_docs.py" \
+        --root "$PORT_ROOT" \
+        --surface "$PORT_ROOT/port_surface.json" \
+        --ignore "$PORT_ROOT/DOC_AUDIT_IGNORE.md"
+
+# Gate 10: SURFACE-DIFF — the public symbol set matches the Python reference
+# surface (modulo documented omissions/additions). DRIFT polices signatures;
+# this polices the symbol set.
+run_gate "SURFACE-DIFF" "diff_port_surface vs python_surface.json" \
+    python3 "$PORTING_SDK_DIR/scripts/diff_port_surface.py" \
+        --reference "$PORTING_SDK_DIR/python_surface.json" \
+        --port-surface "$PORT_ROOT/port_surface.json" \
+        --omissions "$PORT_ROOT/PORT_OMISSIONS.md" \
+        --additions "$PORT_ROOT/PORT_ADDITIONS.md"
+
+# Gate 11: SKILL-CONTRACT — each built-in skill's SWAIG tool contract
+# (name/parameters/required/enum) matches the Python reference. Sibling of
+# EMISSION for skills; scripts/emit-skills.sh wraps tools/EmitSkills.
+run_gate "SKILL-CONTRACT" "diff_skill_contracts vs python reference" \
+    python3 "$PORTING_SDK_DIR/scripts/diff_skill_contracts.py" \
+        --dump-cmd "bash $PORT_ROOT/scripts/emit-skills.sh" \
+        --port-repo "$PORT_ROOT"
 
 if [ -z "$FAILED_GATES" ]; then
     echo "==> CI PASS"

--- a/src/SignalWire/Agent/AgentBase.cs
+++ b/src/SignalWire/Agent/AgentBase.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using SignalWire.Contexts;
@@ -143,6 +144,7 @@ public class AgentBase : Service
     //  Constructor
     // ======================================================================
 
+    [SuppressMessage("Design", "CA1062", Justification = "options is consumed by the base initializer, which runs before any constructor-body guard could; a null argument fails fast there. Guarding earlier is not possible without a non-idiomatic static throw-helper around the base call.")]
     public AgentBase(AgentOptions options) : base(new ServiceOptions
     {
         Name = options.Name,
@@ -264,10 +266,10 @@ public class AgentBase : Service
     public AgentBase PromptAddSection(
         string title,
         string body = "",
-        List<string>? bullets = null,
+        IReadOnlyList<string>? bullets = null,
         bool numbered = false,
         bool numberedBullets = false,
-        List<Dictionary<string, object>>? subsections = null)
+        IReadOnlyList<Dictionary<string, object>>? subsections = null)
     {
         _usePom = true;
         var section = new Dictionary<string, object>
@@ -277,13 +279,13 @@ public class AgentBase : Service
         };
         if (bullets is { Count: > 0 })
         {
-            section["bullets"] = bullets;
+            section["bullets"] = bullets.ToList();
         }
         if (numbered) section["numbered"] = true;
         if (numberedBullets) section["numbered_bullets"] = true;
         if (subsections is not null && subsections.Count > 0)
         {
-            section["subsections"] = subsections;
+            section["subsections"] = subsections.ToList();
         }
         _pomSections.Add(section);
         return this;
@@ -295,7 +297,7 @@ public class AgentBase : Service
         string parentTitle,
         string title,
         string body = "",
-        List<string>? bullets = null)
+        IReadOnlyList<string>? bullets = null)
     {
         foreach (var section in _pomSections)
         {
@@ -313,7 +315,7 @@ public class AgentBase : Service
                         ["title"] = title,
                         ["body"] = body,
                     };
-                    if (bullets is { Count: > 0 }) sub["bullets"] = bullets;
+                    if (bullets is { Count: > 0 }) sub["bullets"] = bullets.ToList();
                     subs.Add(sub);
                 }
                 break;
@@ -329,7 +331,7 @@ public class AgentBase : Service
         string title,
         string? body = null,
         string? bullet = null,
-        List<string>? bullets = null)
+        IReadOnlyList<string>? bullets = null)
     {
         foreach (var section in _pomSections)
         {
@@ -371,6 +373,7 @@ public class AgentBase : Service
     /// <summary>
     /// Return the prompt payload: POM array if enabled and populated, otherwise raw text.
     /// </summary>
+    [SuppressMessage("Design", "CA1024", Justification = "get_* accessor matches the cross-port surface (Python agent.get_prompt()).")]
     public object GetPrompt()
     {
         if (_usePom && _pomSections.Count > 0)
@@ -396,7 +399,7 @@ public class AgentBase : Service
     /// <summary>Set the prompt as a list-of-section dicts (POM form).
     /// Throws when ``UsePom`` is false. (Python parity:
     /// ``PromptManager.set_prompt_pom``.)</summary>
-    public AgentBase SetPromptPom(List<Dictionary<string, object>> pom)
+    public AgentBase SetPromptPom(IReadOnlyList<Dictionary<string, object>> pom)
     {
         if (!_usePom)
         {
@@ -412,6 +415,7 @@ public class AgentBase : Service
     /// <c>UsePom</c> is false. Materialised on each access from the
     /// internal list-of-dicts so mutations stay round-trip-safe. To
     /// inspect raw section dicts, use <see cref="GetPromptSections"/>.</summary>
+    [SuppressMessage("Design", "CA1031", Justification = "Property accessor must not throw on malformed section data; on any parse failure it falls back to an empty POM instead of propagating the exception.")]
     public POM.PromptObjectModel? Pom
     {
         get
@@ -435,10 +439,12 @@ public class AgentBase : Service
     /// <summary>The raw POM section dicts. Mirrors how the dotnet
     /// agent has historically stored its prompt-object data and how
     /// SWML rendering consumes it. Read-only snapshot.</summary>
+    [SuppressMessage("Design", "CA1024", Justification = "get_* accessor matches the cross-port surface (Python agent.get_prompt_sections()).")]
     public IReadOnlyList<Dictionary<string, object>> GetPromptSections() => _pomSections;
 
     /// <summary>Create a per-call SWAIG-function token. Returns empty
     /// string on failure. (Python parity: ``StateMixin._create_tool_token``.)</summary>
+    [SuppressMessage("Design", "CA1031", Justification = "Best-effort token creation; any failure returns an empty string to match the Python reference's swallow-and-fallback behavior.")]
     public string CreateToolToken(string toolName, string callId)
     {
         try
@@ -455,6 +461,7 @@ public class AgentBase : Service
     /// when the function is not registered, when the SessionManager
     /// rejects the token, or on any error. (Python parity:
     /// ``StateMixin.validate_tool_token``.)</summary>
+    [SuppressMessage("Design", "CA1031", Justification = "Best-effort token validation; any failure is treated as an invalid token (returns false) to match the Python reference's swallow-and-reject behavior.")]
     public bool ValidateToolToken(string functionName, string token, string callId)
     {
         if (!HasFunction(functionName))
@@ -484,8 +491,9 @@ public class AgentBase : Service
         return this;
     }
 
-    public AgentBase AddHints(List<string> hints)
+    public AgentBase AddHints(IReadOnlyList<string> hints)
     {
+        ArgumentNullException.ThrowIfNull(hints);
         _hints.AddRange(hints);
         return this;
     }
@@ -586,14 +594,16 @@ public class AgentBase : Service
         return null;
     }
 
-    public AgentBase SetLanguages(List<Dictionary<string, object>> languages)
+    public AgentBase SetLanguages(IReadOnlyList<Dictionary<string, object>> languages)
     {
-        _languages = languages;
+        ArgumentNullException.ThrowIfNull(languages);
+        _languages = [.. languages];
         return this;
     }
 
     public AgentBase AddPronunciation(string replace, string with, string ignore = "")
     {
+        ArgumentNullException.ThrowIfNull(ignore);
         var entry = new Dictionary<string, object>
         {
             ["replace"] = replace,
@@ -607,9 +617,10 @@ public class AgentBase : Service
         return this;
     }
 
-    public AgentBase SetPronunciations(List<Dictionary<string, object>> pronunciations)
+    public AgentBase SetPronunciations(IReadOnlyList<Dictionary<string, object>> pronunciations)
     {
-        _pronunciations = pronunciations;
+        ArgumentNullException.ThrowIfNull(pronunciations);
+        _pronunciations = [.. pronunciations];
         return this;
     }
 
@@ -633,6 +644,7 @@ public class AgentBase : Service
 
     public AgentBase UpdateGlobalData(Dictionary<string, object> data)
     {
+        ArgumentNullException.ThrowIfNull(data);
         foreach (var (key, value) in data)
         {
             _globalData[key] = value;
@@ -640,9 +652,10 @@ public class AgentBase : Service
         return this;
     }
 
-    public AgentBase SetNativeFunctions(List<string> functions)
+    public AgentBase SetNativeFunctions(IReadOnlyList<string> functions)
     {
-        _nativeFunctions = functions;
+        ArgumentNullException.ThrowIfNull(functions);
+        _nativeFunctions = [.. functions];
         return this;
     }
 
@@ -670,9 +683,10 @@ public class AgentBase : Service
         "get_ideal_strategy",       // thinking (enable_thinking)
     };
 
-    public AgentBase SetInternalFillers(List<string> fillers)
+    public AgentBase SetInternalFillers(IReadOnlyList<string> fillers)
     {
-        _internalFillers = fillers;
+        ArgumentNullException.ThrowIfNull(fillers);
+        _internalFillers = [.. fillers];
         return this;
     }
 
@@ -742,8 +756,9 @@ public class AgentBase : Service
     /// for the complete list of supported function names and what fillers
     /// do. Names outside the supported set log a warning.</para>
     /// </summary>
-    public AgentBase AddInternalFiller(string functionName, string languageCode, List<string> fillers)
+    public AgentBase AddInternalFiller(string functionName, string languageCode, IReadOnlyList<string> fillers)
     {
+        ArgumentNullException.ThrowIfNull(fillers);
         if (!SupportedInternalFillerNames.Contains(functionName))
         {
             var supportedStr = "[" + string.Join(", ",
@@ -759,7 +774,7 @@ public class AgentBase : Service
             langMap = [];
             _internalFillersMap[functionName] = langMap;
         }
-        langMap[languageCode] = fillers;
+        langMap[languageCode] = [.. fillers];
         return this;
     }
 
@@ -775,9 +790,10 @@ public class AgentBase : Service
         return this;
     }
 
-    public AgentBase SetFunctionIncludes(List<Dictionary<string, object>> includes)
+    public AgentBase SetFunctionIncludes(IReadOnlyList<Dictionary<string, object>> includes)
     {
-        _functionIncludes = includes;
+        ArgumentNullException.ThrowIfNull(includes);
+        _functionIncludes = [.. includes];
         return this;
     }
 
@@ -893,6 +909,8 @@ public class AgentBase : Service
     // ======================================================================
 
     /// <summary>Return the skill manager, creating it lazily on first access.</summary>
+    [SuppressMessage("Design", "CA1024", Justification = "get_* accessor matches the cross-port surface (Python agent.get_skill_manager()); also has the lazy-init side effect of creating the manager.")]
+    [SuppressMessage("Naming", "CA1721", Justification = "GetSkillManager() and the SkillManager property both intentionally exist to mirror the Python reference surface (get_skill_manager() + skill_manager).")]
     public SkillManager GetSkillManager()
     {
         _skillManager ??= new SkillManager(this);
@@ -900,9 +918,12 @@ public class AgentBase : Service
     }
 
     /// <summary>Skill manager (Python parity: ``agent.skill_manager``).</summary>
+    [SuppressMessage("Naming", "CA1721", Justification = "The SkillManager property and GetSkillManager() both intentionally exist to mirror the Python reference surface (skill_manager + get_skill_manager()).")]
     public SkillManager SkillManager => GetSkillManager();
 
     /// <summary>Return the agent name (Python parity: ``agent.get_name()``).</summary>
+    [SuppressMessage("Design", "CA1024", Justification = "get_* accessor matches the cross-port surface (Python agent.get_name()).")]
+    [SuppressMessage("Naming", "CA1721", Justification = "GetName() and the inherited Name property both intentionally exist to mirror the Python reference surface (get_name() + name).")]
     public string GetName() => Name;
 
     // ``GetFullUrl(bool includeAuth = false)`` is inherited from
@@ -918,7 +939,7 @@ public class AgentBase : Service
         return this;
     }
 
-    private bool _autoMapSipUsernames = false;
+    private bool _autoMapSipUsernames;
     public bool IsAutoMapSipUsernames => _autoMapSipUsernames;
 
     /// <summary>
@@ -971,7 +992,7 @@ public class AgentBase : Service
     public AgentBase RemoveSkill(SkillName name) => RemoveSkill(name.ToWireName());
 
     /// <summary>List all loaded skill instance keys.</summary>
-    public List<string> ListSkills()
+    public IReadOnlyList<string> ListSkills()
     {
         if (_skillManager is not null)
         {
@@ -1006,12 +1027,14 @@ public class AgentBase : Service
         return this;
     }
 
+    [SuppressMessage("Usage", "CA1054", Justification = "URL is a wire string sent verbatim to the SignalWire API")]
     public AgentBase SetWebHookUrl(string url)
     {
         _webhookUrl = url;
         return this;
     }
 
+    [SuppressMessage("Usage", "CA1054", Justification = "URL is a wire string sent verbatim to the SignalWire API")]
     public AgentBase SetPostPromptUrl(string url)
     {
         _postPromptUrl = url;
@@ -1019,14 +1042,17 @@ public class AgentBase : Service
     }
 
     /// <summary>Manually override the proxy URL used for SWAIG webhook construction.</summary>
+    [SuppressMessage("Usage", "CA1054", Justification = "URL is a wire string sent verbatim to the SignalWire API")]
     public AgentBase ManualSetProxyUrl(string url)
     {
+        ArgumentNullException.ThrowIfNull(url);
         _manualProxyUrl = url.TrimEnd('/');
         return this;
     }
 
     public AgentBase AddSwaigQueryParams(Dictionary<string, string> parameters)
     {
+        ArgumentNullException.ThrowIfNull(parameters);
         foreach (var (key, value) in parameters)
         {
             _swaigQueryParams[key] = value;
@@ -1073,6 +1099,7 @@ public class AgentBase : Service
 
     public AgentBase RegisterSipUsername(string username, string route = "")
     {
+        ArgumentNullException.ThrowIfNull(route);
         SetParam("sip_username", username);
         if (route.Length > 0)
         {
@@ -1298,6 +1325,8 @@ public class AgentBase : Service
         Dictionary<string, string> headers,
         string? body)
     {
+        ArgumentNullException.ThrowIfNull(path);
+
         // Validation is opt-in: when no signing key is configured, the
         // base dispatch handles the request as before.
         if (_webhookValidationMiddleware is null)

--- a/src/SignalWire/Contexts/ContextBuilder.cs
+++ b/src/SignalWire/Contexts/ContextBuilder.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace SignalWire.Contexts;
 
 /// <summary>
@@ -38,6 +40,7 @@ public class GatherQuestion
 
     public GatherQuestion(Dictionary<string, object> opts)
     {
+        ArgumentNullException.ThrowIfNull(opts);
         _key = (string)opts["key"];
         _question = (string)opts["question"];
         _type = opts.TryGetValue("type", out var t) ? (string)t : "string";
@@ -85,7 +88,7 @@ public class GatherInfo
         return this;
     }
 
-    public List<GatherQuestion> Questions => _questions;
+    public IReadOnlyList<GatherQuestion> Questions => _questions;
     public string? CompletionAction => _completionAction;
 
     public Dictionary<string, object> ToDict()
@@ -109,8 +112,8 @@ public class Step
     private string? _text;
     private string? _stepCriteria;
     private object? _functions;
-    private List<string>? _validSteps;
-    private List<string>? _validContexts;
+    private IReadOnlyList<string>? _validSteps;
+    private IReadOnlyList<string>? _validContexts;
     private List<Dictionary<string, object>> _sections = [];
     private GatherInfo? _gatherInfo;
     private bool _end;
@@ -141,11 +144,12 @@ public class Step
         return this;
     }
 
-    public Step AddBullets(string title, List<string> bullets)
+    public Step AddBullets(string title, IReadOnlyList<string> bullets)
     {
+        ArgumentNullException.ThrowIfNull(bullets);
         if (_text is not null)
             throw new InvalidOperationException("Cannot add POM sections when SetText() has been used.");
-        _sections.Add(new Dictionary<string, object> { ["title"] = title, ["bullets"] = bullets });
+        _sections.Add(new Dictionary<string, object> { ["title"] = title, ["bullets"] = new List<string>(bullets) });
         return this;
     }
 
@@ -197,8 +201,8 @@ public class Step
     /// </param>
     public Step SetFunctions(object functions) { _functions = functions; return this; }
 
-    public Step SetValidSteps(List<string> steps) { _validSteps = steps; return this; }
-    public Step SetValidContexts(List<string> contexts) { _validContexts = contexts; return this; }
+    public Step SetValidSteps(IReadOnlyList<string> steps) { _validSteps = steps; return this; }
+    public Step SetValidContexts(IReadOnlyList<string> contexts) { _validContexts = contexts; return this; }
 
     /// <summary>
     /// Mark this step as terminal for the step flow.
@@ -221,6 +225,7 @@ public class Step
 
     public Step SetGatherInfo(Dictionary<string, object> opts)
     {
+        ArgumentNullException.ThrowIfNull(opts);
         _gatherInfo = new GatherInfo(
             opts.TryGetValue("output_key", out var ok) ? (string)ok : null,
             opts.TryGetValue("completion_action", out var ca) ? (string)ca : null,
@@ -265,8 +270,8 @@ public class Step
     public Step SetResetConsolidate(bool consolidate) { _resetConsolidate = consolidate; return this; }
     public Step SetResetFullReset(bool fullReset) { _resetFullReset = fullReset; return this; }
 
-    public List<string>? ValidSteps => _validSteps;
-    public List<string>? ValidContexts => _validContexts;
+    public IReadOnlyList<string>? ValidSteps => _validSteps;
+    public IReadOnlyList<string>? ValidContexts => _validContexts;
     public GatherInfo? GatherInfoData => _gatherInfo;
 
     private string RenderText()
@@ -328,8 +333,8 @@ public class Context
     private readonly string _name;
     private readonly Dictionary<string, Step> _steps = [];
     private readonly List<string> _stepOrder = [];
-    private List<string>? _validContexts;
-    private List<string>? _validSteps;
+    private IReadOnlyList<string>? _validContexts;
+    private IReadOnlyList<string>? _validSteps;
     private string? _initialStep;
     private string? _postPrompt;
     private string? _systemPrompt;
@@ -390,8 +395,13 @@ public class Context
         return this;
     }
 
-    public Dictionary<string, Step> GetSteps() => _steps;
-    public List<string> GetStepOrder() => [.. _stepOrder];
+    [SuppressMessage("Design", "CA1024:Use properties where appropriate",
+        Justification = "get_* accessor matches the cross-port surface")]
+    public IReadOnlyDictionary<string, Step> GetSteps() => _steps;
+
+    [SuppressMessage("Design", "CA1024:Use properties where appropriate",
+        Justification = "get_* accessor matches the cross-port surface")]
+    public IReadOnlyList<string> GetStepOrder() => [.. _stepOrder];
 
     // -- Prompt (plain text vs POM) --
 
@@ -411,11 +421,12 @@ public class Context
         return this;
     }
 
-    public Context AddBullets(string title, List<string> bullets)
+    public Context AddBullets(string title, IReadOnlyList<string> bullets)
     {
+        ArgumentNullException.ThrowIfNull(bullets);
         if (_promptText is not null)
             throw new InvalidOperationException("Cannot add POM sections when SetPrompt() has been used.");
-        _promptSections.Add(new Dictionary<string, object> { ["title"] = title, ["bullets"] = bullets });
+        _promptSections.Add(new Dictionary<string, object> { ["title"] = title, ["bullets"] = new List<string>(bullets) });
         return this;
     }
 
@@ -437,11 +448,12 @@ public class Context
         return this;
     }
 
-    public Context AddSystemBullets(string title, List<string> bullets)
+    public Context AddSystemBullets(string title, IReadOnlyList<string> bullets)
     {
+        ArgumentNullException.ThrowIfNull(bullets);
         if (_systemPrompt is not null)
             throw new InvalidOperationException("Cannot add POM sections when SetSystemPrompt() has been used.");
-        _systemPromptSections.Add(new Dictionary<string, object> { ["title"] = title, ["bullets"] = bullets });
+        _systemPromptSections.Add(new Dictionary<string, object> { ["title"] = title, ["bullets"] = new List<string>(bullets) });
         return this;
     }
 
@@ -457,10 +469,12 @@ public class Context
     /// <param name="stepName">Name of the step to start on (must exist in this context).</param>
     public Context SetInitialStep(string stepName) { _initialStep = stepName; return this; }
 
+    [SuppressMessage("Design", "CA1024:Use properties where appropriate",
+        Justification = "get_* accessor matches the cross-port surface")]
     public string? GetInitialStep() => _initialStep;
 
-    public Context SetValidContexts(List<string> contexts) { _validContexts = contexts; return this; }
-    public Context SetValidSteps(List<string> steps) { _validSteps = steps; return this; }
+    public Context SetValidContexts(IReadOnlyList<string> contexts) { _validContexts = contexts; return this; }
+    public Context SetValidSteps(IReadOnlyList<string> steps) { _validSteps = steps; return this; }
     public Context SetPostPrompt(string postPrompt) { _postPrompt = postPrompt; return this; }
     public Context SetConsolidate(bool consolidate) { _consolidate = consolidate; return this; }
     public Context SetFullReset(bool fullReset) { _fullReset = fullReset; return this; }
@@ -509,7 +523,9 @@ public class Context
         return this;
     }
 
-    public List<string>? GetValidContexts() => _validContexts;
+    [SuppressMessage("Design", "CA1024:Use properties where appropriate",
+        Justification = "get_* accessor matches the cross-port surface")]
+    public IReadOnlyList<string>? GetValidContexts() => _validContexts;
 
     // -- Rendering helpers --
 
@@ -636,7 +652,7 @@ public class ContextBuilder
     public Context? GetContext(string name) => _contexts.TryGetValue(name, out var c) ? c : null;
     public bool HasContexts() => _contexts.Count > 0;
 
-    public List<string> Validate()
+    public IReadOnlyList<string> Validate()
     {
         var errors = new List<string>();
         if (_contexts.Count == 0) { errors.Add("At least one context must be defined"); return errors; }
@@ -712,7 +728,7 @@ public class ContextBuilder
 
         foreach (var (contextName, context) in _contexts)
         {
-            var stepOrder = context.GetStepOrder();
+            var stepOrder = context.GetStepOrder().ToList();
             foreach (var (stepName, step) in context.GetSteps())
             {
                 var gi = step.GatherInfoData;

--- a/src/SignalWire/DataMap/DataMap.cs
+++ b/src/SignalWire/DataMap/DataMap.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using SignalWire.SWAIG;
 
 namespace SignalWire.DataMap;
@@ -84,7 +85,7 @@ public class DataMap
         string type,
         string description,
         bool required = false,
-        List<string>? enumValues = null)
+        IReadOnlyList<string>? enumValues = null)
     {
         var prop = new Dictionary<string, object>
         {
@@ -94,7 +95,7 @@ public class DataMap
 
         if (enumValues is { Count: > 0 })
         {
-            prop["enum"] = enumValues;
+            prop["enum"] = new List<string>(enumValues);
         }
 
         _properties[name] = prop;
@@ -129,14 +130,17 @@ public class DataMap
         return this;
     }
 
+    [SuppressMessage("Usage", "CA1054:URI-like parameters should not be strings",
+        Justification = "URL is a wire string sent verbatim to the SignalWire API")]
     public DataMap Webhook(
         string method,
         string url,
         Dictionary<string, string>? headers = null,
         string formParam = "",
         bool inputArgsAsParams = false,
-        List<string>? requireArgs = null)
+        IReadOnlyList<string>? requireArgs = null)
     {
+        ArgumentNullException.ThrowIfNull(formParam);
         var wh = new Dictionary<string, object>
         {
             ["method"] = method,
@@ -157,16 +161,17 @@ public class DataMap
         }
         if (requireArgs is { Count: > 0 })
         {
-            wh["require_args"] = requireArgs;
+            wh["require_args"] = new List<string>(requireArgs);
         }
 
         _webhooks.Add(wh);
         return this;
     }
 
-    public DataMap WebhookExpressions(List<Dictionary<string, object>> expressions)
+    public DataMap WebhookExpressions(IReadOnlyList<Dictionary<string, object>> expressions)
     {
-        if (_webhooks.Count > 0) _webhooks[^1]["expressions"] = expressions;
+        ArgumentNullException.ThrowIfNull(expressions);
+        if (_webhooks.Count > 0) _webhooks[^1]["expressions"] = new List<Dictionary<string, object>>(expressions);
         return this;
     }
 
@@ -201,15 +206,17 @@ public class DataMap
         return this;
     }
 
-    public DataMap ErrorKeys(List<string> keys)
+    public DataMap ErrorKeys(IReadOnlyList<string> keys)
     {
-        if (_webhooks.Count > 0) _webhooks[^1]["error_keys"] = keys;
+        ArgumentNullException.ThrowIfNull(keys);
+        if (_webhooks.Count > 0) _webhooks[^1]["error_keys"] = new List<string>(keys);
         return this;
     }
 
-    public DataMap GlobalErrorKeys(List<string> keys)
+    public DataMap GlobalErrorKeys(IReadOnlyList<string> keys)
     {
-        _globalErrorKeys = keys;
+        ArgumentNullException.ThrowIfNull(keys);
+        _globalErrorKeys = new List<string>(keys);
         return this;
     }
 
@@ -242,11 +249,14 @@ public class DataMap
 
     // -- Static Helpers --
 
+    [SuppressMessage("Usage", "CA1054:URI-like parameters should not be strings",
+        Justification = "URL is a wire string sent verbatim to the SignalWire API")]
     public static Dictionary<string, object> CreateSimpleApiTool(
-        string name, string purpose, List<Dictionary<string, object>> parameters,
+        string name, string purpose, IReadOnlyList<Dictionary<string, object>> parameters,
         string method, string url, object output,
         Dictionary<string, string>? headers = null)
     {
+        ArgumentNullException.ThrowIfNull(parameters);
         var builder = new DataMap(name);
         builder.Purpose(purpose);
         foreach (var p in parameters)
@@ -262,9 +272,11 @@ public class DataMap
     }
 
     public static Dictionary<string, object> CreateExpressionTool(
-        string name, string purpose, List<Dictionary<string, object>> parameters,
-        List<Dictionary<string, object>> expressions)
+        string name, string purpose, IReadOnlyList<Dictionary<string, object>> parameters,
+        IReadOnlyList<Dictionary<string, object>> expressions)
     {
+        ArgumentNullException.ThrowIfNull(parameters);
+        ArgumentNullException.ThrowIfNull(expressions);
         var builder = new DataMap(name);
         builder.Purpose(purpose);
         foreach (var p in parameters)

--- a/src/SignalWire/Logging/Logger.cs
+++ b/src/SignalWire/Logging/Logger.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace SignalWire.Logging;
 
 public enum LogLevel
@@ -58,7 +60,7 @@ public sealed class Logger
     {
         if (!ShouldLog(level)) return;
 
-        var timestamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
+        var timestamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
         var upper = level.ToString().ToUpperInvariant();
         Console.Error.WriteLine($"[{timestamp}] [{upper}] [{Name}] {message}");
     }
@@ -66,12 +68,12 @@ public sealed class Logger
     private static LogLevel? ParseLevel(string? value)
     {
         if (string.IsNullOrEmpty(value)) return null;
-        return value.ToLowerInvariant() switch
+        return value.ToUpperInvariant() switch
         {
-            "debug" => LogLevel.Debug,
-            "info" => LogLevel.Info,
-            "warn" => LogLevel.Warn,
-            "error" => LogLevel.Error,
+            "DEBUG" => LogLevel.Debug,
+            "INFO" => LogLevel.Info,
+            "WARN" => LogLevel.Warn,
+            "ERROR" => LogLevel.Error,
             _ => null,
         };
     }

--- a/src/SignalWire/POM/PomBuilder.cs
+++ b/src/SignalWire/POM/PomBuilder.cs
@@ -26,10 +26,10 @@ public class PomBuilder
     public PomBuilder AddSection(
         string title,
         string body = "",
-        List<string>? bullets = null,
+        IReadOnlyList<string>? bullets = null,
         bool numbered = false,
         bool numberedBullets = false,
-        List<Dictionary<string, object>>? subsections = null)
+        IReadOnlyList<Dictionary<string, object>>? subsections = null)
     {
         var section = Pom.AddSection(title, body, bullets, numbered, numberedBullets);
         _sections[title] = section;
@@ -54,7 +54,7 @@ public class PomBuilder
         string title,
         string? body = null,
         string? bullet = null,
-        List<string>? bullets = null)
+        IReadOnlyList<string>? bullets = null)
     {
         if (!_sections.ContainsKey(title))
         {
@@ -69,11 +69,11 @@ public class PomBuilder
         }
         if (!string.IsNullOrEmpty(bullet))
         {
-            section.Bullets.Add(bullet);
+            section.BulletsMutable.Add(bullet);
         }
         if (bullets is not null)
         {
-            section.Bullets.AddRange(bullets);
+            section.BulletsMutable.AddRange(bullets);
         }
         return this;
     }
@@ -85,7 +85,7 @@ public class PomBuilder
         string parentTitle,
         string title,
         string body = "",
-        List<string>? bullets = null)
+        IReadOnlyList<string>? bullets = null)
     {
         if (!_sections.ContainsKey(parentTitle))
         {
@@ -111,14 +111,14 @@ public class PomBuilder
     public string RenderXml() => Pom.RenderXml();
 
     /// <summary>Serialize the POM to a list of section dicts.</summary>
-    public List<Dictionary<string, object>> ToDict() => Pom.ToDict();
+    public IReadOnlyList<Dictionary<string, object>> ToDict() => Pom.ToDict();
 
     /// <summary>Serialize the POM to a JSON string.</summary>
     public string ToJson() => Pom.ToJson();
 
     /// <summary>Build a PomBuilder from a list of section dicts.
     /// (Python parity: ``PomBuilder.from_sections`` classmethod.)</summary>
-    public static PomBuilder FromSections(List<Dictionary<string, object>> sections)
+    public static PomBuilder FromSections(IReadOnlyList<Dictionary<string, object>> sections)
     {
         var builder = new PomBuilder();
         var json = JsonSerializer.Serialize(sections);

--- a/src/SignalWire/POM/PromptObjectModel.cs
+++ b/src/SignalWire/POM/PromptObjectModel.cs
@@ -19,6 +19,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
@@ -34,7 +35,13 @@ public class Section
 
     public string Body { get; set; }
 
-    public List<string> Bullets { get; }
+    private readonly List<string> _bullets;
+
+    public IReadOnlyList<string> Bullets => _bullets;
+
+    /// <summary>Mutable backing store for <see cref="Bullets"/>, used by
+    /// builders within the assembly to append bullets in place.</summary>
+    internal List<string> BulletsMutable => _bullets;
 
     /// <summary>Three-state numbering: null = inherit, true = force on,
     /// false = force off. (Python parity: ``numbered`` is
@@ -45,21 +52,27 @@ public class Section
 
     public bool NumberedBullets { get; set; }
 
-    public List<Section> Subsections { get; }
+    private readonly List<Section> _subsections;
+
+    public IReadOnlyList<Section> Subsections => _subsections;
+
+    /// <summary>Mutable backing store for <see cref="Subsections"/>, used by
+    /// builders within the assembly to append subsections in place.</summary>
+    internal List<Section> SubsectionsMutable => _subsections;
 
     public Section(
         string? title = null,
         string body = "",
-        List<string>? bullets = null,
+        IReadOnlyList<string>? bullets = null,
         bool? numbered = null,
         bool numberedBullets = false)
     {
         Title = title;
         Body = body;
-        Bullets = bullets is null ? new List<string>() : new List<string>(bullets);
+        _bullets = bullets is null ? new List<string>() : new List<string>(bullets);
         Numbered = numbered;
         NumberedBullets = numberedBullets;
-        Subsections = new List<Section>();
+        _subsections = new List<Section>();
     }
 
     /// <summary>Set or replace this section's body text.
@@ -72,9 +85,10 @@ public class Section
 
     /// <summary>Append bullets to this section.
     /// (Python parity: ``Section.add_bullets``.)</summary>
-    public Section AddBullets(List<string> bullets)
+    public Section AddBullets(IReadOnlyList<string> bullets)
     {
-        Bullets.AddRange(bullets);
+        ArgumentNullException.ThrowIfNull(bullets);
+        _bullets.AddRange(bullets);
         return this;
     }
 
@@ -83,21 +97,21 @@ public class Section
     public Section AddSubsection(
         string? title = null,
         string body = "",
-        List<string>? bullets = null,
+        IReadOnlyList<string>? bullets = null,
         bool? numbered = null,
         bool numberedBullets = false)
     {
         if (title is null)
             throw new ArgumentException("Subsections must have a title");
         var sub = new Section(title, body, bullets, numbered, numberedBullets);
-        Subsections.Add(sub);
+        _subsections.Add(sub);
         return sub;
     }
 
     /// <summary>Render this section as a markdown fragment, indented at
     /// the given header level (default 2). Mirrors Python's
     /// ``Section.render_markdown`` exactly.</summary>
-    public string RenderMarkdown(int level = 2, List<int>? sectionNumber = null)
+    public string RenderMarkdown(int level = 2, IReadOnlyList<int>? sectionNumber = null)
     {
         sectionNumber ??= new List<int>();
         var md = new List<string>();
@@ -107,7 +121,7 @@ public class Section
         {
             string prefix = "";
             if (sectionNumber.Count > 0)
-                prefix = string.Join(".", sectionNumber.Select(n => n.ToString())) + ". ";
+                prefix = string.Join(".", sectionNumber.Select(n => n.ToString(CultureInfo.InvariantCulture))) + ". ";
             md.Add($"{new string('#', level)} {prefix}{Title}\n");
         }
 
@@ -134,7 +148,7 @@ public class Section
         for (int i = 0; i < Subsections.Count; i++)
         {
             var subsection = Subsections[i];
-            List<int> newSectionNumber;
+            IReadOnlyList<int> newSectionNumber;
             int nextLevel;
             if (Title is not null || sectionNumber.Count > 0)
             {
@@ -162,7 +176,7 @@ public class Section
     /// <summary>Render this section as an XML fragment. Mirrors
     /// Python's ``Section.render_xml`` exactly (no HTML escaping; uses
     /// `<bullets>` / `<subsections>` wrapping containers).</summary>
-    public string RenderXml(int indent = 0, List<int>? sectionNumber = null)
+    public string RenderXml(int indent = 0, IReadOnlyList<int>? sectionNumber = null)
     {
         sectionNumber ??= new List<int>();
         string indentStr = new string(' ', indent * 2);
@@ -174,7 +188,7 @@ public class Section
         {
             string prefix = "";
             if (sectionNumber.Count > 0)
-                prefix = string.Join(".", sectionNumber.Select(n => n.ToString())) + ". ";
+                prefix = string.Join(".", sectionNumber.Select(n => n.ToString(CultureInfo.InvariantCulture))) + ". ";
             xml.Add($"{indentStr}  <title>{prefix}{Title}</title>");
         }
 
@@ -202,7 +216,7 @@ public class Section
             for (int i = 0; i < Subsections.Count; i++)
             {
                 var subsection = Subsections[i];
-                List<int> newSectionNumber;
+                IReadOnlyList<int> newSectionNumber;
                 if (Title is not null || sectionNumber.Count > 0)
                 {
                     if (anySubsectionNumbered && subsection.Numbered != false)
@@ -250,6 +264,12 @@ public class Section
 
 public class PromptObjectModel
 {
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+    };
+
     private readonly List<Section> _sections;
     public bool Debug { get; set; }
 
@@ -267,7 +287,7 @@ public class PromptObjectModel
     public Section AddSection(
         string? title = null,
         string body = "",
-        List<string>? bullets = null,
+        IReadOnlyList<string>? bullets = null,
         bool? numbered = null,
         bool numberedBullets = false)
     {
@@ -370,7 +390,7 @@ public class PromptObjectModel
 
     /// <summary>Serialize to a list of dicts (matches Python's to_dict
     /// which returns a List rather than a Dict).</summary>
-    public List<Dictionary<string, object>> ToDict() =>
+    public IReadOnlyList<Dictionary<string, object>> ToDict() =>
         _sections.Select(s => s.ToDict()).ToList();
 
     /// <summary>Serialize to JSON string with 2-space indent and Python
@@ -378,14 +398,9 @@ public class PromptObjectModel
     public string ToJson()
     {
         if (_sections.Count == 0) return "[]";
-        var options = new JsonSerializerOptions
-        {
-            WriteIndented = true,
-            Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-        };
         // System.Text.Json indents with 2 spaces by default in .NET 9+.
         var dicts = ToDict();
-        return JsonSerializer.Serialize(dicts, options);
+        return JsonSerializer.Serialize(dicts, JsonOptions);
     }
 
     /// <summary>Serialize to YAML string. Matches PyYAML's
@@ -489,7 +504,7 @@ public class PromptObjectModel
         {
             foreach (var item in bulletsEl.EnumerateArray())
                 if (item.ValueKind == JsonValueKind.String)
-                    s.Bullets.Add(item.GetString() ?? "");
+                    s.BulletsMutable.Add(item.GetString() ?? "");
         }
 
         if (el.TryGetProperty("numbered", out var n))
@@ -503,7 +518,7 @@ public class PromptObjectModel
         if (hasSubsections)
         {
             foreach (var sub in subsEl.EnumerateArray())
-                s.Subsections.Add(SectionFromJson(sub, isSubsection: true));
+                s.SubsectionsMutable.Add(SectionFromJson(sub, isSubsection: true));
         }
 
         return s;
@@ -514,6 +529,7 @@ public class PromptObjectModel
     /// (Python parity: ``PromptObjectModel.add_pom_as_subsection``.)</summary>
     public void AddPomAsSubsection(string targetTitle, PromptObjectModel pomToAdd)
     {
+        ArgumentNullException.ThrowIfNull(pomToAdd);
         var target = FindSection(targetTitle);
         if (target is null)
             throw new ArgumentException($"No section with title '{targetTitle}' found.");
@@ -523,9 +539,14 @@ public class PromptObjectModel
     /// <summary>Add a PromptObjectModel as a subsection of an existing
     /// Section object directly. Overload mirrors Python's polymorphism.
     /// (Python parity: ``PromptObjectModel.add_pom_as_subsection``.)</summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Performance", "CA1822:Mark members as static",
+        Justification = "Instance overload mirrors the AddPomAsSubsection(string, ...) sibling and the cross-port instance surface.")]
     public void AddPomAsSubsection(Section target, PromptObjectModel pomToAdd)
     {
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(pomToAdd);
         foreach (var s in pomToAdd.Sections)
-            target.Subsections.Add(s);
+            target.SubsectionsMutable.Add(s);
     }
 }

--- a/src/SignalWire/Prefabs/ConciergeAgent.cs
+++ b/src/SignalWire/Prefabs/ConciergeAgent.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using SignalWire.Agent;
 using SignalWire.SWAIG;
 
@@ -19,6 +20,7 @@ public class ConciergeAgent : AgentBase
         Dictionary<string, object>? options = null)
         : base(CreateOptions(name, options))
     {
+        ArgumentNullException.ThrowIfNull(venueInfo);
         _venueName = venueInfo.TryGetValue("venue_name", out var vn) ? vn as string ?? "Venue" : "Venue";
         _services = venueInfo.TryGetValue("services", out var sv) && sv is List<string> sl ? sl : [];
         _amenities = venueInfo.TryGetValue("amenities", out var am) && am is Dictionary<string, Dictionary<string, object>> ad ? ad : [];
@@ -91,6 +93,7 @@ public class ConciergeAgent : AgentBase
     /// (Python parity: ``ConciergeAgent.check_availability(args, raw_data)``.)</summary>
     public FunctionResult CheckAvailability(Dictionary<string, object> args, Dictionary<string, object?> rawData)
     {
+        ArgumentNullException.ThrowIfNull(args);
         var service = args.TryGetValue("service", out var s) ? s as string ?? "" : "";
         var date = args.TryGetValue("date", out var d) ? d as string ?? "" : "";
         var response = $"Checking availability for {service} at {_venueName}";
@@ -102,12 +105,12 @@ public class ConciergeAgent : AgentBase
     /// (Python parity: ``ConciergeAgent.get_directions(args, raw_data)``.)</summary>
     public FunctionResult GetDirections(Dictionary<string, object> args, Dictionary<string, object?> rawData)
     {
+        ArgumentNullException.ThrowIfNull(args);
         var destination = args.TryGetValue("destination", out var d) ? d as string ?? "" : "";
-        var destinationLower = destination.ToLowerInvariant();
 
         foreach (var (amenityName, info) in _amenities)
         {
-            if (amenityName.ToLowerInvariant() == destinationLower)
+            if (amenityName.Equals(destination, StringComparison.OrdinalIgnoreCase))
             {
                 var location = info.TryGetValue("location", out var l) ? l as string ?? "location not specified" : "location not specified";
                 return new FunctionResult($"The {amenityName} at {_venueName} is located at: {location}");
@@ -117,12 +120,18 @@ public class ConciergeAgent : AgentBase
         return new FunctionResult($"Directions to {destination} at {_venueName}: please ask the front desk for assistance.");
     }
 
+    [SuppressMessage("Design", "CA1024", Justification = "get_* accessor matches the cross-port surface")]
     public string GetVenueName() => _venueName;
-    public List<string> GetServices() => _services;
+
+    [SuppressMessage("Design", "CA1024", Justification = "get_* accessor matches the cross-port surface")]
+    public IReadOnlyList<string> GetServices() => _services;
+
+    [SuppressMessage("Design", "CA1024", Justification = "get_* accessor matches the cross-port surface")]
     public Dictionary<string, Dictionary<string, object>> GetAmenities() => _amenities;
 
     private static AgentOptions CreateOptions(string name, Dictionary<string, object>? options)
     {
+        ArgumentNullException.ThrowIfNull(name);
         return new AgentOptions
         {
             Name = name.Length > 0 ? name : "concierge",

--- a/src/SignalWire/Prefabs/FAQBotAgent.cs
+++ b/src/SignalWire/Prefabs/FAQBotAgent.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using SignalWire.Agent;
 using SignalWire.SWAIG;
 
@@ -9,12 +10,12 @@ namespace SignalWire.Prefabs;
 /// </summary>
 public class FAQBotAgent : AgentBase
 {
-    private readonly List<Dictionary<string, object>> _faqs;
+    private readonly IReadOnlyList<Dictionary<string, object>> _faqs;
     private readonly bool _suggestRelated;
 
     public FAQBotAgent(
         string name,
-        List<Dictionary<string, object>> faqs,
+        IReadOnlyList<Dictionary<string, object>> faqs,
         Dictionary<string, object>? options = null)
         : base(CreateOptions(name, options))
     {
@@ -61,8 +62,10 @@ public class FAQBotAgent : AgentBase
     /// <summary>SWAIG tool handler that searches the configured FAQ
     /// knowledge base for the best keyword-scored answer.
     /// (Python parity: ``FAQBotAgent.search_faqs(args, raw_data)``.)</summary>
+    [SuppressMessage("Globalization", "CA1308", Justification = "lowercased query is the normalized value echoed back in the response text verbatim")]
     public FunctionResult SearchFaqs(Dictionary<string, object> args, Dictionary<string, object?> rawData)
     {
+        ArgumentNullException.ThrowIfNull(args);
         var query = (args.TryGetValue("query", out var q) ? q as string ?? "" : "").Trim().ToLowerInvariant();
         if (query.Length == 0) return new FunctionResult("Please provide a search query.");
 
@@ -71,12 +74,12 @@ public class FAQBotAgent : AgentBase
         var scored = new List<(int Score, Dictionary<string, object> Faq)>();
         foreach (var faq in _faqs)
         {
-            var questionLower = (faq.TryGetValue("question", out var qv) ? qv as string ?? "" : "").ToLowerInvariant();
+            var question = faq.TryGetValue("question", out var qv) ? qv as string ?? "" : "";
             var score = 0;
-            if (questionLower.Contains(query)) score += 10;
+            if (question.Contains(query, StringComparison.OrdinalIgnoreCase)) score += 10;
             foreach (var kw in keywords)
             {
-                if (kw.Length > 0 && questionLower.Contains(kw)) score++;
+                if (kw.Length > 0 && question.Contains(kw, StringComparison.OrdinalIgnoreCase)) score++;
             }
             if (score > 0) scored.Add((score, faq));
         }
@@ -96,11 +99,15 @@ public class FAQBotAgent : AgentBase
         return new FunctionResult(response);
     }
 
-    public List<Dictionary<string, object>> GetFaqs() => _faqs;
+    [SuppressMessage("Design", "CA1024", Justification = "get_* accessor matches the cross-port surface")]
+    public IReadOnlyList<Dictionary<string, object>> GetFaqs() => _faqs;
+
+    [SuppressMessage("Design", "CA1024", Justification = "get_* accessor matches the cross-port surface")]
     public bool GetSuggestRelated() => _suggestRelated;
 
     private static AgentOptions CreateOptions(string name, Dictionary<string, object>? options)
     {
+        ArgumentNullException.ThrowIfNull(name);
         return new AgentOptions
         {
             Name = name.Length > 0 ? name : "faq_bot",

--- a/src/SignalWire/Prefabs/InfoGathererAgent.cs
+++ b/src/SignalWire/Prefabs/InfoGathererAgent.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using SignalWire.Agent;
 using SignalWire.SWAIG;
 
@@ -9,14 +10,14 @@ namespace SignalWire.Prefabs;
 /// </summary>
 public class InfoGathererAgent : AgentBase
 {
-    private readonly List<Dictionary<string, object>> _questions;
+    private readonly IReadOnlyList<Dictionary<string, object>> _questions;
 
     /// <param name="name">Agent name (defaults to "info_gatherer").</param>
     /// <param name="questions">List of question dicts with key_name, question_text, and optional confirm.</param>
     /// <param name="options">Additional <see cref="AgentOptions"/> overrides.</param>
     public InfoGathererAgent(
         string name,
-        List<Dictionary<string, object>> questions,
+        IReadOnlyList<Dictionary<string, object>> questions,
         AgentOptions? options = null)
         : base(CreateOptions(name, options))
     {
@@ -69,16 +70,20 @@ public class InfoGathererAgent : AgentBase
 
     /// <summary>SWAIG tool handler for the ``submit_answer`` tool.
     /// (Python parity: ``InfoGathererAgent.submit_answer``.)</summary>
+    [SuppressMessage("Performance", "CA1822", Justification = "instance method matches the cross-port SWAIG tool-handler surface")]
     public FunctionResult SubmitAnswer(Dictionary<string, object> args, Dictionary<string, object?> rawData)
     {
+        ArgumentNullException.ThrowIfNull(args);
         var answer = args.TryGetValue("answer", out var a) ? a as string ?? "" : "";
         return new FunctionResult($"Answer recorded: {answer}");
     }
 
-    public List<Dictionary<string, object>> GetQuestions() => _questions;
+    [SuppressMessage("Design", "CA1024", Justification = "get_* accessor matches the cross-port surface")]
+    public IReadOnlyList<Dictionary<string, object>> GetQuestions() => _questions;
 
     private static AgentOptions CreateOptions(string name, AgentOptions? baseOpts)
     {
+        ArgumentNullException.ThrowIfNull(name);
         return new AgentOptions
         {
             Name = name.Length > 0 ? name : "info_gatherer",

--- a/src/SignalWire/Prefabs/ReceptionistAgent.cs
+++ b/src/SignalWire/Prefabs/ReceptionistAgent.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using SignalWire.Agent;
 using SignalWire.SWAIG;
 
@@ -9,12 +10,12 @@ namespace SignalWire.Prefabs;
 /// </summary>
 public class ReceptionistAgent : AgentBase
 {
-    private readonly List<Dictionary<string, object>> _departments;
+    private readonly IReadOnlyList<Dictionary<string, object>> _departments;
     private readonly string _greeting;
 
     public ReceptionistAgent(
         string name,
-        List<Dictionary<string, object>> departments,
+        IReadOnlyList<Dictionary<string, object>> departments,
         Dictionary<string, object>? options = null)
         : base(CreateOptions(name, options))
     {
@@ -92,11 +93,15 @@ public class ReceptionistAgent : AgentBase
             });
     }
 
-    public List<Dictionary<string, object>> GetDepartments() => _departments;
+    [SuppressMessage("Design", "CA1024", Justification = "get_* accessor matches the cross-port surface")]
+    public IReadOnlyList<Dictionary<string, object>> GetDepartments() => _departments;
+
+    [SuppressMessage("Design", "CA1024", Justification = "get_* accessor matches the cross-port surface")]
     public string GetGreeting() => _greeting;
 
     private static AgentOptions CreateOptions(string name, Dictionary<string, object>? options)
     {
+        ArgumentNullException.ThrowIfNull(name);
         return new AgentOptions
         {
             Name = name.Length > 0 ? name : "receptionist",

--- a/src/SignalWire/Prefabs/SurveyAgent.cs
+++ b/src/SignalWire/Prefabs/SurveyAgent.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using SignalWire.Agent;
 using SignalWire.SWAIG;
 
@@ -10,13 +12,11 @@ namespace SignalWire.Prefabs;
 public class SurveyAgent : AgentBase
 {
     private readonly string _surveyName;
-    private readonly List<Dictionary<string, object>> _surveyQuestions;
-
-    private static readonly string[] ValidTypes = ["rating", "multiple_choice", "yes_no", "open_ended"];
+    private readonly IReadOnlyList<Dictionary<string, object>> _surveyQuestions;
 
     public SurveyAgent(
         string name,
-        List<Dictionary<string, object>> questions,
+        IReadOnlyList<Dictionary<string, object>> questions,
         Dictionary<string, object>? options = null)
         : base(CreateOptions(name, options))
     {
@@ -79,8 +79,10 @@ public class SurveyAgent : AgentBase
 
     /// <summary>SWAIG tool handler for the ``validate_response`` tool.
     /// (Python parity: ``SurveyAgent.validate_response``.)</summary>
+    [SuppressMessage("Globalization", "CA1308", Justification = "normalized lowercase preserves the existing yes/no response value verbatim")]
     public FunctionResult ValidateResponse(Dictionary<string, object> args, Dictionary<string, object?> rawData)
     {
+        ArgumentNullException.ThrowIfNull(args);
         var questionId = args.TryGetValue("question_id", out var qi) ? qi as string ?? "" : "";
         var answer = args.TryGetValue("answer", out var a) ? a as string ?? "" : "";
 
@@ -101,17 +103,17 @@ public class SurveyAgent : AgentBase
         switch (type)
         {
             case "rating":
-                var scale = question.TryGetValue("scale", out var sc) ? Convert.ToInt32(sc) : 5;
+                var scale = question.TryGetValue("scale", out var sc) ? Convert.ToInt32(sc, CultureInfo.InvariantCulture) : 5;
                 if (int.TryParse(answer, out var val) && val >= 1 && val <= scale)
                     return new FunctionResult($"Valid rating: {val}/{scale}");
                 return new FunctionResult($"Invalid rating. Please provide a number between 1 and {scale}.");
 
             case "multiple_choice":
                 var choices = question.TryGetValue("choices", out var ch) && ch is List<string> cl ? cl : [];
-                var lowerAnswer = answer.Trim().ToLowerInvariant();
+                var trimmedAnswer = answer.Trim();
                 foreach (var choice in choices)
                 {
-                    if (choice.Trim().ToLowerInvariant() == lowerAnswer)
+                    if (choice.Trim().Equals(trimmedAnswer, StringComparison.OrdinalIgnoreCase))
                         return new FunctionResult($"Valid choice: {choice}");
                 }
                 return new FunctionResult($"Invalid choice. Valid options are: {string.Join(", ", choices)}");
@@ -131,18 +133,24 @@ public class SurveyAgent : AgentBase
 
     /// <summary>SWAIG tool handler for the ``log_response`` tool.
     /// (Python parity: ``SurveyAgent.log_response``.)</summary>
+    [SuppressMessage("Performance", "CA1822", Justification = "instance method matches the cross-port SWAIG tool-handler surface")]
     public FunctionResult LogResponse(Dictionary<string, object> args, Dictionary<string, object?> rawData)
     {
+        ArgumentNullException.ThrowIfNull(args);
         var questionId = args.TryGetValue("question_id", out var qi) ? qi as string ?? "" : "";
         var answer = args.TryGetValue("answer", out var a) ? a as string ?? "" : "";
         return new FunctionResult($"Survey answer for {questionId}: {answer}");
     }
 
-    public List<Dictionary<string, object>> GetSurveyQuestions() => _surveyQuestions;
+    [SuppressMessage("Design", "CA1024", Justification = "get_* accessor matches the cross-port surface")]
+    public IReadOnlyList<Dictionary<string, object>> GetSurveyQuestions() => _surveyQuestions;
+
+    [SuppressMessage("Design", "CA1024", Justification = "get_* accessor matches the cross-port surface")]
     public string GetSurveyName() => _surveyName;
 
     private static AgentOptions CreateOptions(string name, Dictionary<string, object>? options)
     {
+        ArgumentNullException.ThrowIfNull(name);
         return new AgentOptions
         {
             Name = name.Length > 0 ? name : "survey",

--- a/src/SignalWire/REST/CrudResource.cs
+++ b/src/SignalWire/REST/CrudResource.cs
@@ -20,6 +20,7 @@ public class CrudResource
     /// <summary>Build a full path by appending segments to the base path.</summary>
     protected string Path(params string[] parts)
     {
+        ArgumentNullException.ThrowIfNull(parts);
         if (parts.Length == 0) return BasePath;
         return BasePath + "/" + string.Join("/", parts);
     }

--- a/src/SignalWire/REST/HttpClient.cs
+++ b/src/SignalWire/REST/HttpClient.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
@@ -21,11 +22,14 @@ public class HttpClient : IDisposable
     private readonly string _authHeader;
     private readonly string _userAgent = "signalwire-agents-dotnet-rest/1.0";
 
+    [SuppressMessage("Usage", "CA1054", Justification = "baseUrl is a wire string sent verbatim to the SignalWire API.")]
     public HttpClient(string projectId, string token, string baseUrl)
         : this(projectId, token, baseUrl, null) { }
 
+    [SuppressMessage("Usage", "CA1054", Justification = "baseUrl is a wire string sent verbatim to the SignalWire API.")]
     public HttpClient(string projectId, string token, string baseUrl, System.Net.Http.HttpClient? httpClient)
     {
+        ArgumentNullException.ThrowIfNull(baseUrl);
         _projectId = projectId;
         _token = token;
         _baseUrl = baseUrl.TrimEnd('/');
@@ -45,6 +49,7 @@ public class HttpClient : IDisposable
 
     public string ProjectId => _projectId;
     public string Token => _token;
+    [SuppressMessage("Usage", "CA1056", Justification = "BaseUrl is a wire string sent verbatim to the SignalWire API.")]
     public string BaseUrl => _baseUrl;
     public string AuthHeader => _authHeader;
 

--- a/src/SignalWire/REST/Namespaces/Calling.cs
+++ b/src/SignalWire/REST/Namespaces/Calling.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace SignalWire.REST.Namespaces;
 
 /// <summary>
@@ -22,6 +24,8 @@ public class Calling
 
     public HttpClient Client => _client;
     public string ProjectId => _projectId;
+    [SuppressMessage("Design", "CA1024", Justification = "get_* accessor matches the cross-port surface.")]
+    [SuppressMessage("Performance", "CA1822", Justification = "get_* accessor matches the cross-port surface; kept as an instance member for parity.")]
     public string GetBasePath() => BasePath;
 
     // ------------------------------------------------------------------

--- a/src/SignalWire/REST/Namespaces/Compat.cs
+++ b/src/SignalWire/REST/Namespaces/Compat.cs
@@ -89,9 +89,9 @@ public class CompatCalls : CrudResource
     public CompatCalls(HttpClient client, string basePath) : base(client, basePath) { }
 
     /// <summary>UPDATE uses POST (Twilio compat) — overrides the generic CrudResource PUT.</summary>
-    public override Task<Dictionary<string, object?>> UpdateAsync(string sid, Dictionary<string, object?> kwargs,
+    public override Task<Dictionary<string, object?>> UpdateAsync(string id, Dictionary<string, object?> data,
         CancellationToken cancellationToken = default)
-        => Client.PostAsync(Path(sid), kwargs, cancellationToken);
+        => Client.PostAsync(Path(id), data, cancellationToken);
 
     public Task<Dictionary<string, object?>> StartRecordingAsync(string callSid, Dictionary<string, object?> kwargs)
         => Client.PostAsync(Path(callSid, "Recordings"), kwargs);
@@ -111,9 +111,9 @@ public class CompatMessages : CrudResource
 {
     public CompatMessages(HttpClient client, string basePath) : base(client, basePath) { }
 
-    public override Task<Dictionary<string, object?>> UpdateAsync(string sid, Dictionary<string, object?> kwargs,
+    public override Task<Dictionary<string, object?>> UpdateAsync(string id, Dictionary<string, object?> data,
         CancellationToken cancellationToken = default)
-        => Client.PostAsync(Path(sid), kwargs, cancellationToken);
+        => Client.PostAsync(Path(id), data, cancellationToken);
 
     public Task<Dictionary<string, object?>> ListMediaAsync(string messageSid, Dictionary<string, string>? queryParams = null)
         => Client.GetAsync(Path(messageSid, "Media"), queryParams);
@@ -130,9 +130,9 @@ public class CompatFaxes : CrudResource
 {
     public CompatFaxes(HttpClient client, string basePath) : base(client, basePath) { }
 
-    public override Task<Dictionary<string, object?>> UpdateAsync(string sid, Dictionary<string, object?> kwargs,
+    public override Task<Dictionary<string, object?>> UpdateAsync(string id, Dictionary<string, object?> data,
         CancellationToken cancellationToken = default)
-        => Client.PostAsync(Path(sid), kwargs, cancellationToken);
+        => Client.PostAsync(Path(id), data, cancellationToken);
 
     public Task<Dictionary<string, object?>> ListMediaAsync(string faxSid, Dictionary<string, string>? queryParams = null)
         => Client.GetAsync(Path(faxSid, "Media"), queryParams);
@@ -211,10 +211,11 @@ public class CompatPhoneNumbers
 
     public CompatPhoneNumbers(HttpClient client, string basePath)
     {
+        ArgumentNullException.ThrowIfNull(basePath);
         _client = client;
         _basePath = basePath;
-        _availableBase = basePath.Replace("/IncomingPhoneNumbers", "/AvailablePhoneNumbers");
-        _importedBase = basePath.Replace("/IncomingPhoneNumbers", "/ImportedPhoneNumbers");
+        _availableBase = basePath.Replace("/IncomingPhoneNumbers", "/AvailablePhoneNumbers", StringComparison.Ordinal);
+        _importedBase = basePath.Replace("/IncomingPhoneNumbers", "/ImportedPhoneNumbers", StringComparison.Ordinal);
     }
 
     public string BasePath => _basePath;
@@ -255,9 +256,9 @@ public class CompatApplications : CrudResource
 {
     public CompatApplications(HttpClient client, string basePath) : base(client, basePath) { }
 
-    public override Task<Dictionary<string, object?>> UpdateAsync(string sid, Dictionary<string, object?> kwargs,
+    public override Task<Dictionary<string, object?>> UpdateAsync(string id, Dictionary<string, object?> data,
         CancellationToken cancellationToken = default)
-        => Client.PostAsync(Path(sid), kwargs, cancellationToken);
+        => Client.PostAsync(Path(id), data, cancellationToken);
 }
 
 /// <summary>Compat cXML / LaML script bins.</summary>
@@ -265,9 +266,9 @@ public class CompatLamlBins : CrudResource
 {
     public CompatLamlBins(HttpClient client, string basePath) : base(client, basePath) { }
 
-    public override Task<Dictionary<string, object?>> UpdateAsync(string sid, Dictionary<string, object?> kwargs,
+    public override Task<Dictionary<string, object?>> UpdateAsync(string id, Dictionary<string, object?> data,
         CancellationToken cancellationToken = default)
-        => Client.PostAsync(Path(sid), kwargs, cancellationToken);
+        => Client.PostAsync(Path(id), data, cancellationToken);
 }
 
 /// <summary>Compat queues with member management.</summary>
@@ -275,9 +276,9 @@ public class CompatQueues : CrudResource
 {
     public CompatQueues(HttpClient client, string basePath) : base(client, basePath) { }
 
-    public override Task<Dictionary<string, object?>> UpdateAsync(string sid, Dictionary<string, object?> kwargs,
+    public override Task<Dictionary<string, object?>> UpdateAsync(string id, Dictionary<string, object?> data,
         CancellationToken cancellationToken = default)
-        => Client.PostAsync(Path(sid), kwargs, cancellationToken);
+        => Client.PostAsync(Path(id), data, cancellationToken);
 
     public Task<Dictionary<string, object?>> ListMembersAsync(string queueSid, Dictionary<string, string>? queryParams = null)
         => Client.GetAsync(Path(queueSid, "Members"), queryParams);

--- a/src/SignalWire/REST/Namespaces/FabricExtras.cs
+++ b/src/SignalWire/REST/Namespaces/FabricExtras.cs
@@ -153,10 +153,11 @@ public class CallFlowsHelper
 
     public CallFlowsHelper(HttpClient client, string basePath)
     {
+        ArgumentNullException.ThrowIfNull(basePath);
         _client = client;
         _basePath = basePath;
         // Sub-resource paths use singular 'call_flow' per the API spec.
-        _singularBase = basePath.Replace("/call_flows", "/call_flow");
+        _singularBase = basePath.Replace("/call_flows", "/call_flow", StringComparison.Ordinal);
     }
 
     public string BasePath => _basePath;
@@ -183,9 +184,10 @@ public class ConferenceRoomsHelper
 
     public ConferenceRoomsHelper(HttpClient client, string basePath)
     {
+        ArgumentNullException.ThrowIfNull(basePath);
         _client = client;
         _basePath = basePath;
-        _singularBase = basePath.Replace("/conference_rooms", "/conference_room");
+        _singularBase = basePath.Replace("/conference_rooms", "/conference_room", StringComparison.Ordinal);
     }
 
     public string BasePath => _basePath;

--- a/src/SignalWire/REST/Namespaces/SmallNamespaces.cs
+++ b/src/SignalWire/REST/Namespaces/SmallNamespaces.cs
@@ -63,9 +63,9 @@ public class ShortCodes : CrudResource
 {
     public ShortCodes(HttpClient client) : base(client, "/api/relay/rest/short_codes") { }
 
-    public override Task<Dictionary<string, object?>> UpdateAsync(string id, Dictionary<string, object?> kwargs,
+    public override Task<Dictionary<string, object?>> UpdateAsync(string id, Dictionary<string, object?> data,
         CancellationToken cancellationToken = default)
-        => Client.PutAsync(Path(id), kwargs, cancellationToken);
+        => Client.PutAsync(Path(id), data, cancellationToken);
 }
 
 /// <summary>
@@ -81,9 +81,9 @@ public class NumberGroups : CrudResource
     public NumberGroups(HttpClient client)
         : base(client, "/api/relay/rest/number_groups") { }
 
-    public override Task<Dictionary<string, object?>> UpdateAsync(string id, Dictionary<string, object?> kwargs,
+    public override Task<Dictionary<string, object?>> UpdateAsync(string id, Dictionary<string, object?> data,
         CancellationToken cancellationToken = default)
-        => Client.PutAsync(Path(id), kwargs, cancellationToken);
+        => Client.PutAsync(Path(id), data, cancellationToken);
 
     public Task<Dictionary<string, object?>> ListMembershipsAsync(string groupId, Dictionary<string, string>? queryParams = null)
         => Client.GetAsync(Path(groupId, "number_group_memberships"), queryParams);
@@ -216,9 +216,9 @@ public class Queues : CrudResource
     public Queues(HttpClient client)
         : base(client, "/api/relay/rest/queues") { }
 
-    public override Task<Dictionary<string, object?>> UpdateAsync(string id, Dictionary<string, object?> kwargs,
+    public override Task<Dictionary<string, object?>> UpdateAsync(string id, Dictionary<string, object?> data,
         CancellationToken cancellationToken = default)
-        => Client.PutAsync(Path(id), kwargs, cancellationToken);
+        => Client.PutAsync(Path(id), data, cancellationToken);
 
     public Task<Dictionary<string, object?>> ListMembersAsync(string queueId, Dictionary<string, string>? queryParams = null)
         => Client.GetAsync(Path(queueId, "members"), queryParams);

--- a/src/SignalWire/REST/Namespaces/Video.cs
+++ b/src/SignalWire/REST/Namespaces/Video.cs
@@ -47,9 +47,9 @@ public class VideoRooms : CrudResource
     public VideoRooms(HttpClient client, string basePath) : base(client, basePath) { }
 
     /// <summary>Update via PUT (matching Python's _update_method = "PUT").</summary>
-    public override Task<Dictionary<string, object?>> UpdateAsync(string id, Dictionary<string, object?> kwargs,
+    public override Task<Dictionary<string, object?>> UpdateAsync(string id, Dictionary<string, object?> data,
         CancellationToken cancellationToken = default)
-        => Client.PutAsync(Path(id), kwargs, cancellationToken);
+        => Client.PutAsync(Path(id), data, cancellationToken);
 
     public Task<Dictionary<string, object?>> ListStreamsAsync(string roomId, Dictionary<string, string>? queryParams = null)
         => Client.GetAsync(Path(roomId, "streams"), queryParams);
@@ -144,9 +144,9 @@ public class VideoConferences : CrudResource
 {
     public VideoConferences(HttpClient client, string basePath) : base(client, basePath) { }
 
-    public override Task<Dictionary<string, object?>> UpdateAsync(string id, Dictionary<string, object?> kwargs,
+    public override Task<Dictionary<string, object?>> UpdateAsync(string id, Dictionary<string, object?> data,
         CancellationToken cancellationToken = default)
-        => Client.PutAsync(Path(id), kwargs, cancellationToken);
+        => Client.PutAsync(Path(id), data, cancellationToken);
 
     public Task<Dictionary<string, object?>> ListConferenceTokensAsync(string conferenceId, Dictionary<string, string>? queryParams = null)
         => Client.GetAsync(Path(conferenceId, "conference_tokens"), queryParams);

--- a/src/SignalWire/REST/PaginatedIterator.cs
+++ b/src/SignalWire/REST/PaginatedIterator.cs
@@ -48,7 +48,7 @@ public class PaginatedIterator : IAsyncEnumerable<Dictionary<string, object?>>
     public Dictionary<string, string>? Params => _params;
     public string DataKey => _dataKey;
     public int Index => _index;
-    public List<Dictionary<string, object?>> Items => _items;
+    public IReadOnlyList<Dictionary<string, object?>> Items => _items;
     public bool Done => _done;
 
     /// <summary>Returns the next item, or throws InvalidOperationException

--- a/src/SignalWire/REST/RestClient.cs
+++ b/src/SignalWire/REST/RestClient.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using SignalWire.REST.Namespaces;
 
 namespace SignalWire.REST;
@@ -73,6 +74,7 @@ public class RestClient : IDisposable
     public string ProjectId => _projectId;
     public string Token => _token;
     public string Space => _space;
+    [SuppressMessage("Usage", "CA1056", Justification = "BaseUrl is a wire string sent verbatim to the SignalWire API.")]
     public string BaseUrl => _baseUrl;
     public HttpClient Http => _http;
 

--- a/src/SignalWire/REST/SignalWireRestError.cs
+++ b/src/SignalWire/REST/SignalWireRestError.cs
@@ -1,9 +1,12 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace SignalWire.REST;
 
 /// <summary>
 /// Exception thrown when a SignalWire REST API call returns a non-2xx status
 /// or encounters a transport-level error.
 /// </summary>
+[SuppressMessage("Naming", "CA1710", Justification = "SignalWireRestError is the cross-port surface name shared across all 10 SDK ports; renaming would break parity.")]
 public sealed class SignalWireRestError : Exception
 {
     /// <summary>HTTP status code from the response (0 for transport errors).</summary>
@@ -11,6 +14,26 @@ public sealed class SignalWireRestError : Exception
 
     /// <summary>Raw response body from the server.</summary>
     public string ResponseBody { get; }
+
+    /// <summary>Initializes a new instance with default values.</summary>
+    public SignalWireRestError()
+    {
+        ResponseBody = string.Empty;
+    }
+
+    /// <summary>Initializes a new instance with a message.</summary>
+    public SignalWireRestError(string message)
+        : base(message)
+    {
+        ResponseBody = string.Empty;
+    }
+
+    /// <summary>Initializes a new instance with a message and inner exception.</summary>
+    public SignalWireRestError(string message, Exception innerException)
+        : base(message, innerException)
+    {
+        ResponseBody = string.Empty;
+    }
 
     public SignalWireRestError(string message, int statusCode, string responseBody)
         : base(message)

--- a/src/SignalWire/Relay/Action.cs
+++ b/src/SignalWire/Relay/Action.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using SignalWire.Logging;
 
 namespace SignalWire.Relay;
@@ -17,15 +19,19 @@ public class Action
     private Func<Action, Task>? _onCompletedCallback;
     private bool _callbackFired;
 
+    [SuppressMessage("Naming", "CA1721", Justification = "Both the property and the get_* accessor are part of the cross-port surface; the GetControlId() accessor matches the cross-port-named accessor.")]
     public string ControlId { get; }
+    [SuppressMessage("Naming", "CA1721", Justification = "Both the property and the get_* accessor are part of the cross-port surface; the GetCallId() accessor matches the cross-port-named accessor.")]
     public string CallId { get; }
+    [SuppressMessage("Naming", "CA1721", Justification = "Both the property and the get_* accessor are part of the cross-port surface; the GetNodeId() accessor matches the cross-port-named accessor.")]
     public string NodeId { get; }
     protected object Client { get; }
 
     public string? State { get; protected set; }
     public bool Completed { get; private set; }
     public object? Result { get; private set; }
-    public List<Event> Events { get; } = [];
+    private readonly List<Event> _events = [];
+    public IReadOnlyList<Event> Events => _events;
     public Dictionary<string, object?> Payload { get; private set; } = new();
 
     public Action(string controlId, string callId, string nodeId, object client)
@@ -63,8 +69,14 @@ public class Action
     // ------------------------------------------------------------------
 
     public bool IsDone => Completed;
+
+    [SuppressMessage("Design", "CA1024", Justification = "get_* accessor matches the cross-port surface")]
     public string GetControlId() => ControlId;
+
+    [SuppressMessage("Design", "CA1024", Justification = "get_* accessor matches the cross-port surface")]
     public string GetCallId() => CallId;
+
+    [SuppressMessage("Design", "CA1024", Justification = "get_* accessor matches the cross-port surface")]
     public string GetNodeId() => NodeId;
 
     // ------------------------------------------------------------------
@@ -102,7 +114,8 @@ public class Action
     /// </summary>
     public virtual void HandleEvent(Event evt)
     {
-        Events.Add(evt);
+        ArgumentNullException.ThrowIfNull(evt);
+        _events.Add(evt);
 
         foreach (var kvp in evt.Params)
         {
@@ -248,15 +261,16 @@ public class RecordAction : Action
 
     public void Resume() => ExecuteSubcommand("calling.record.resume");
 
+    [SuppressMessage("Usage", "CA1056", Justification = "URL is a wire string sent verbatim to the SignalWire API")]
     public string? Url => Payload.TryGetValue("url", out var v) ? v?.ToString() : null;
 
     public double? Duration =>
         Payload.TryGetValue("duration", out var v) && v is not null
-            ? Convert.ToDouble(v) : null;
+            ? Convert.ToDouble(v, CultureInfo.InvariantCulture) : null;
 
     public int? Size =>
         Payload.TryGetValue("size", out var v) && v is not null
-            ? Convert.ToInt32(v) : null;
+            ? Convert.ToInt32(v, CultureInfo.InvariantCulture) : null;
 }
 
 /// <summary>
@@ -304,6 +318,7 @@ public class CollectAction : Action
     /// </summary>
     public override void HandleEvent(Event evt)
     {
+        ArgumentNullException.ThrowIfNull(evt);
         if (evt.EventType == "calling.call.play") return;
         base.HandleEvent(evt);
     }
@@ -337,6 +352,7 @@ public class DetectAction : Action
     /// </summary>
     public override void HandleEvent(Event evt)
     {
+        ArgumentNullException.ThrowIfNull(evt);
         base.HandleEvent(evt);
         if (Completed) return;
         if (evt.Params.TryGetValue("detect", out var d) && d is not null)

--- a/src/SignalWire/Relay/Call.cs
+++ b/src/SignalWire/Relay/Call.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using SignalWire.Logging;
 
 namespace SignalWire.Relay;
@@ -32,8 +33,8 @@ public class Call
     public CallState? CallState =>
         CallStateExtensions.TryParse(State, out var s) ? s : null;
 
-    public Dictionary<string, object?> Device { get; set; } = new();
-    public Dictionary<string, object?> Peer { get; set; } = new();
+    public Dictionary<string, object?> Device { get; private set; } = new();
+    public Dictionary<string, object?> Peer { get; private set; } = new();
     public string? EndReason { get; set; }
     public string? Context { get; set; }
     public string? Direction { get; set; }
@@ -45,8 +46,10 @@ public class Call
     /// <summary>controlId => Action</summary>
     public Dictionary<string, Action> Actions { get; } = new();
 
+    private readonly List<System.Action<Event, Call>> _onEventCallbacks = [];
+
     /// <summary>User-registered event callbacks (catch-all).</summary>
-    public List<System.Action<Event, Call>> OnEventCallbacks { get; } = [];
+    public IReadOnlyList<System.Action<Event, Call>> OnEventCallbacks => _onEventCallbacks;
 
     /// <summary>Per-event-type listeners registered via <see cref="On(string, System.Action{Event})"/>.</summary>
     public Dictionary<string, List<System.Action<Event>>> TypedListeners { get; } = new();
@@ -55,22 +58,23 @@ public class Call
     // Construction
     // ------------------------------------------------------------------
 
-    public Call(Dictionary<string, object?> params_, Client client)
+    public Call(Dictionary<string, object?> parameters, Client client)
     {
+        ArgumentNullException.ThrowIfNull(parameters);
         Client = client;
-        CallId = GetStr(params_, "call_id");
-        NodeId = GetStr(params_, "node_id");
-        Tag = GetStr(params_, "tag");
-        Context = GetStr(params_, "context");
-        Direction = GetStr(params_, "direction");
+        CallId = GetStr(parameters, "call_id");
+        NodeId = GetStr(parameters, "node_id");
+        Tag = GetStr(parameters, "tag");
+        Context = GetStr(parameters, "context");
+        Direction = GetStr(parameters, "direction");
         // Production wire uses "call_state"; legacy synthetic frames use "state".
-        State = GetStr(params_, "call_state")
-            ?? GetStr(params_, "state")
+        State = GetStr(parameters, "call_state")
+            ?? GetStr(parameters, "state")
             ?? Constants.CallStateCreated;
 
-        if (params_.TryGetValue("device", out var d) && d is Dictionary<string, object?> dev)
+        if (parameters.TryGetValue("device", out var d) && d is Dictionary<string, object?> dev)
             Device = dev;
-        if (params_.TryGetValue("peer", out var p) && p is Dictionary<string, object?> peer)
+        if (parameters.TryGetValue("peer", out var p) && p is Dictionary<string, object?> peer)
             Peer = peer;
     }
 
@@ -82,8 +86,10 @@ public class Call
     /// Central event router invoked by the Client whenever a server event
     /// targets this call.
     /// </summary>
+    [SuppressMessage("Design", "CA1031", Justification = "User-registered event callbacks run at a handler boundary; a faulty callback is logged and must not abort event dispatch to other listeners.")]
     public void DispatchEvent(Event evt)
     {
+        ArgumentNullException.ThrowIfNull(evt);
         var eventType = evt.EventType;
         var parms = evt.Params;
 
@@ -173,7 +179,7 @@ public class Call
     /// <summary>Register a generic event listener on this call.</summary>
     public Call On(System.Action<Event, Call> callback)
     {
-        OnEventCallbacks.Add(callback);
+        _onEventCallbacks.Add(callback);
         return this;
     }
 
@@ -364,6 +370,7 @@ public class Call
     }
 
     /// <summary>Play an audio file from a URL. Typed convenience over <see cref="Play"/>.</summary>
+    [SuppressMessage("Usage", "CA1054", Justification = "URL is a wire string sent verbatim to the SignalWire API")]
     public PlayAction PlayAudio(
         string url,
         double? volume = null,
@@ -535,6 +542,7 @@ public class Call
     }
 
     /// <summary>Play an audio file then collect input. Typed media over <see cref="PlayAndCollect"/>.</summary>
+    [SuppressMessage("Usage", "CA1054", Justification = "URL is a wire string sent verbatim to the SignalWire API")]
     public CollectAction PromptAudio(
         string url,
         Dictionary<string, object?> collect,

--- a/src/SignalWire/Relay/Client.cs
+++ b/src/SignalWire/Relay/Client.cs
@@ -1,4 +1,6 @@
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Net.WebSockets;
 using System.Text;
 using System.Text.Json;
@@ -26,7 +28,8 @@ public class Client : IAsyncDisposable
     public string Token { get; }
     public string Host { get; set; }
     public string Scheme { get; set; }
-    public List<string> Contexts { get; } = [];
+    private readonly List<string> _contexts = [];
+    public IReadOnlyList<string> Contexts => _contexts;
     public bool Connected { get; set; }
     public string? SessionId { get; set; }
     public string? Protocol { get; set; }
@@ -98,7 +101,7 @@ public class Client : IAsyncDisposable
         var ctxs = options.GetValueOrDefault("contexts", "");
         if (!string.IsNullOrEmpty(ctxs))
         {
-            Contexts.AddRange(ctxs.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+            _contexts.AddRange(ctxs.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
         }
 
         Host = options.GetValueOrDefault("host", "")
@@ -165,7 +168,9 @@ public class Client : IAsyncDisposable
         _reconnectDelay = 1;
 
         // Start the reader loop so authentication responses and events route correctly.
-        _readerTask = Task.Run(() => ReadLoopAsync(_cts.Token));
+        // The reader loop's lifetime is governed by the internal _cts, not the
+        // caller's connect token; pass None to Task.Run to mark this intentional.
+        _readerTask = Task.Run(() => ReadLoopAsync(_cts.Token), CancellationToken.None);
 
         await AuthenticateAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -227,6 +232,7 @@ public class Client : IAsyncDisposable
     }
 
     /// <summary>Gracefully close the connection.</summary>
+    [SuppressMessage("Design", "CA1031", Justification = "Best-effort teardown: the close handshake and token cancellation must not throw out of Disconnect; any transport error is logged and swallowed.")]
     public void Disconnect()
     {
         _logger.Info("Disconnecting");
@@ -274,6 +280,7 @@ public class Client : IAsyncDisposable
     /// close handshake), cancels the reader loop, waits briefly for it to
     /// unwind, then disposes every owned resource.</para>
     /// </summary>
+    [SuppressMessage("Design", "CA1031", Justification = "Best-effort disposal: the close handshake, token cancellation, and reader drain must each not throw out of DisposeAsync; any error is logged and swallowed so cleanup continues.")]
     public async ValueTask DisposeAsync()
     {
         if (_disposed) return;
@@ -304,7 +311,13 @@ public class Client : IAsyncDisposable
 
         // Cancel the reader loop and let it unwind before we dispose the socket
         // out from under it.
-        try { _cts?.Cancel(); }
+        try
+        {
+            if (_cts is not null)
+            {
+                await _cts.CancelAsync().ConfigureAwait(false);
+            }
+        }
         catch (Exception ex) { _logger.Debug($"DisposeAsync cts cancel error: {ex.Message}"); }
 
         var reader = _readerTask;
@@ -356,6 +369,7 @@ public class Client : IAsyncDisposable
     /// into <see cref="InboundQueue"/>; production reads come from the
     /// WebSocket reader started in <see cref="ConnectAsync"/>.
     /// </summary>
+    [SuppressMessage("Design", "CA1031", Justification = "Resilience boundary: a read/processing error in the event loop is logged and triggers reconnect rather than tearing down the loop; mirrors the reference SDK's run-loop recovery.")]
     public async Task RunAsync(CancellationToken cancellationToken = default)
     {
         if (!Connected)
@@ -399,6 +413,7 @@ public class Client : IAsyncDisposable
     /// each completed message into <see cref="HandleMessage"/>. Handles
     /// fragmented frames by accumulating them until <see cref="ValueWebSocketReceiveResult.EndOfMessage"/>.
     /// </summary>
+    [SuppressMessage("Design", "CA1031", Justification = "Transport boundary: a malformed frame or unexpected processing error is logged; HandleMessage failures must not kill the socket reader. Specific transport exceptions (OperationCanceled, WebSocketException) are already handled distinctly.")]
     public async Task ReadLoopAsync(CancellationToken cancellation)
     {
         if (_ws is null) return;
@@ -432,7 +447,7 @@ public class Client : IAsyncDisposable
                     break;
                 }
 
-                assembled.Write(buffer, 0, result.Count);
+                await assembled.WriteAsync(buffer.AsMemory(0, result.Count), cancellation).ConfigureAwait(false);
 
                 if (!result.EndOfMessage) continue;
 
@@ -474,7 +489,7 @@ public class Client : IAsyncDisposable
     /// Returns the "result" portion of the response.
     /// </summary>
     public async Task<Dictionary<string, object?>> ExecuteAsync(
-        string method, Dictionary<string, object?>? params_ = null,
+        string method, Dictionary<string, object?>? parameters = null,
         CancellationToken cancellationToken = default)
     {
         var id = Guid.NewGuid().ToString();
@@ -484,7 +499,7 @@ public class Client : IAsyncDisposable
             ["jsonrpc"] = "2.0",
             ["id"] = id,
             ["method"] = method,
-            ["params"] = params_ ?? new Dictionary<string, object?>(),
+            ["params"] = parameters ?? new Dictionary<string, object?>(),
         };
 
         var tcs = new TaskCompletionSource<Dictionary<string, object?>>(
@@ -526,6 +541,7 @@ public class Client : IAsyncDisposable
     /// Encode and send a JSON message. Real production path writes to the
     /// WebSocket; tests override this to capture payloads in memory.
     /// </summary>
+    [SuppressMessage("Design", "CA1031", Justification = "Best-effort send: a transport-level send error is logged; it must not propagate out of the fire-and-forget Send path and crash the caller.")]
     public virtual void Send(Dictionary<string, object?> msg)
     {
         var json = JsonSerializer.Serialize(msg, JsonOptions);
@@ -580,6 +596,7 @@ public class Client : IAsyncDisposable
     // ==================================================================
 
     /// <summary>Parse a raw JSON string from the server and route it.</summary>
+    [SuppressMessage("Design", "CA1031", Justification = "Tolerant parse boundary: an unparseable inbound frame is logged and dropped rather than crashing the dispatcher.")]
     public void HandleMessage(string raw)
     {
         _logger.Debug($"<< {raw}");
@@ -601,7 +618,7 @@ public class Client : IAsyncDisposable
         var id = data.GetValueOrDefault("id")?.ToString();
         if (id is not null && Pending.TryGetValue(id, out var tcs))
         {
-            if (data.ContainsKey("error") && data["error"] is Dictionary<string, object?> err)
+            if (data.TryGetValue("error", out var errVal) && errVal is Dictionary<string, object?> err)
             {
                 var code = err.GetValueOrDefault("code")?.ToString() ?? "0";
                 var message = err.GetValueOrDefault("message")?.ToString() ?? "Unknown RPC error";
@@ -642,6 +659,7 @@ public class Client : IAsyncDisposable
     }
 
     /// <summary>Route a signalwire.event payload to the appropriate handler.</summary>
+    [SuppressMessage("Design", "CA1031", Justification = "Handler boundary: a faulty user-supplied on_message handler is logged and must not abort event routing for other events.")]
     public void HandleEvent(Dictionary<string, object?> outerParams)
     {
         var eventType = outerParams.GetValueOrDefault("event_type")?.ToString() ?? "";
@@ -768,21 +786,25 @@ public class Client : IAsyncDisposable
     /// resolve-or-throw deadline.
     /// </summary>
     public async Task<Call> DialAsync(
-        Dictionary<string, object?> params_, CancellationToken cancellationToken = default)
+        Dictionary<string, object?> parameters, CancellationToken cancellationToken = default)
     {
-        var explicitTag = params_.GetValueOrDefault("tag")?.ToString();
+        ArgumentNullException.ThrowIfNull(parameters);
+        var explicitTag = parameters.GetValueOrDefault("tag")?.ToString();
         var tag = !string.IsNullOrEmpty(explicitTag)
             ? explicitTag
             : Guid.NewGuid().ToString();
 
         var timeoutSeconds = 120.0;
-        if (params_.TryGetValue("dial_timeout", out var dt) && dt is not null)
+        if (parameters.TryGetValue("dial_timeout", out var dt) && dt is not null)
         {
             try
             {
-                timeoutSeconds = Convert.ToDouble(dt);
+                timeoutSeconds = Convert.ToDouble(dt, CultureInfo.InvariantCulture);
             }
-            catch { /* fall back to default */ }
+            catch (Exception ex) when (ex is FormatException or InvalidCastException or OverflowException)
+            {
+                // fall back to default
+            }
         }
 
         var tcs = new TaskCompletionSource<Call>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -791,7 +813,7 @@ public class Client : IAsyncDisposable
         // Build the wire params: drop the SDK-only "dial_timeout" field and
         // ensure tag is set (won't double-set if caller passed it through).
         var rpcParams = new Dictionary<string, object?>();
-        foreach (var kvp in params_)
+        foreach (var kvp in parameters)
         {
             if (kvp.Key == "dial_timeout") continue;
             rpcParams[kvp.Key] = kvp.Value;
@@ -827,12 +849,13 @@ public class Client : IAsyncDisposable
 
     /// <summary>Send an outbound message.</summary>
     public async Task<Message> SendMessageAsync(
-        Dictionary<string, object?> params_, CancellationToken cancellationToken = default)
+        Dictionary<string, object?> parameters, CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(parameters);
         // Default the context like Python does: prefer the assigned protocol
         // (not the WS-level signalwire protocol; this is the per-connection
         // routing scope) and fall back to "default".
-        var sendParams = new Dictionary<string, object?>(params_);
+        var sendParams = new Dictionary<string, object?>(parameters);
         if (!sendParams.ContainsKey("context"))
         {
             sendParams["context"] = !string.IsNullOrEmpty(Protocol) ? Protocol : "default";
@@ -863,9 +886,9 @@ public class Client : IAsyncDisposable
         var ctxList = contexts.ToList();
         foreach (var ctx in ctxList)
         {
-            if (!Contexts.Contains(ctx))
+            if (!_contexts.Contains(ctx))
             {
-                Contexts.Add(ctx);
+                _contexts.Add(ctx);
             }
         }
 
@@ -882,7 +905,7 @@ public class Client : IAsyncDisposable
         IEnumerable<string> contexts, CancellationToken cancellationToken = default)
     {
         var ctxList = contexts.ToList();
-        Contexts.RemoveAll(c => ctxList.Contains(c));
+        _contexts.RemoveAll(c => ctxList.Contains(c));
 
         await ExecuteAsync("signalwire.unreceive", new()
         {
@@ -915,6 +938,7 @@ public class Client : IAsyncDisposable
     //  Private helpers
     // ==================================================================
 
+    [SuppressMessage("Design", "CA1031", Justification = "Handler boundary: a faulty user-supplied on_call handler is logged and must not abort inbound-call routing.")]
     private void HandleInboundCall(Event evt, Dictionary<string, object?> parms)
     {
         var callId = parms.GetValueOrDefault("call_id")?.ToString();

--- a/src/SignalWire/Relay/Device.cs
+++ b/src/SignalWire/Relay/Device.cs
@@ -52,11 +52,11 @@ public sealed class Device
     /// Build a device from its discriminant and (optional) params payload.
     /// </summary>
     /// <param name="type">The device type discriminant (required).</param>
-    /// <param name="params_">The device params; an empty map when omitted.</param>
-    public Device(string type, Dictionary<string, object?>? params_ = null)
+    /// <param name="parameters">The device params; an empty map when omitted.</param>
+    public Device(string type, Dictionary<string, object?>? parameters = null)
     {
         Type = type ?? throw new ArgumentNullException(nameof(type));
-        Params = params_ ?? new Dictionary<string, object?>();
+        Params = parameters ?? new Dictionary<string, object?>();
     }
 
     /// <summary>

--- a/src/SignalWire/Relay/Event.cs
+++ b/src/SignalWire/Relay/Event.cs
@@ -11,10 +11,10 @@ public sealed class Event
     public double Timestamp { get; }
     public Dictionary<string, object?> Params { get; }
 
-    public Event(string eventType, Dictionary<string, object?> params_, double timestamp = 0)
+    public Event(string eventType, Dictionary<string, object?> parameters, double timestamp = 0)
     {
         EventType = eventType;
-        Params = params_;
+        Params = parameters;
         Timestamp = timestamp > 0 ? timestamp : DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() / 1000.0;
     }
 
@@ -40,8 +40,8 @@ public sealed class Event
     };
 
     /// <summary>Factory: parse an event from its type and params.</summary>
-    public static Event Parse(string eventType, Dictionary<string, object?> params_)
-        => new(eventType, params_);
+    public static Event Parse(string eventType, Dictionary<string, object?> parameters)
+        => new(eventType, parameters);
 
     // ------------------------------------------------------------------
     // Internal

--- a/src/SignalWire/Relay/Message.cs
+++ b/src/SignalWire/Relay/Message.cs
@@ -23,8 +23,8 @@ public sealed class Message
     public string? FromNumber { get; }
     public string? ToNumber { get; }
     public string? Body { get; private set; }
-    public List<string> Media { get; private set; }
-    public List<string> Tags { get; private set; }
+    public IReadOnlyList<string> Media { get; private set; }
+    public IReadOnlyList<string> Tags { get; private set; }
     public string? State { get; private set; }
 
     /// <summary>
@@ -45,21 +45,21 @@ public sealed class Message
     /// <summary>
     /// Build a Message from a params dictionary (as returned by the server).
     /// </summary>
-    public Message(Dictionary<string, object?>? params_ = null)
+    public Message(Dictionary<string, object?>? parameters = null)
     {
-        params_ ??= new();
+        parameters ??= new();
 
-        MessageId = GetStr(params_, "message_id") ?? GetStr(params_, "id");
-        Context = GetStr(params_, "context");
-        Direction = GetStr(params_, "direction");
-        FromNumber = GetStr(params_, "from_number") ?? GetStr(params_, "from");
-        ToNumber = GetStr(params_, "to_number") ?? GetStr(params_, "to");
-        Body = GetStr(params_, "body");
-        Media = GetStringList(params_, "media");
-        Tags = GetStringList(params_, "tags");
+        MessageId = GetStr(parameters, "message_id") ?? GetStr(parameters, "id");
+        Context = GetStr(parameters, "context");
+        Direction = GetStr(parameters, "direction");
+        FromNumber = GetStr(parameters, "from_number") ?? GetStr(parameters, "from");
+        ToNumber = GetStr(parameters, "to_number") ?? GetStr(parameters, "to");
+        Body = GetStr(parameters, "body");
+        Media = GetStringList(parameters, "media");
+        Tags = GetStringList(parameters, "tags");
         // Production wire uses "message_state"; legacy paths use "state".
-        State = GetStr(params_, "message_state") ?? GetStr(params_, "state");
-        Reason = GetStr(params_, "reason");
+        State = GetStr(parameters, "message_state") ?? GetStr(parameters, "state");
+        Reason = GetStr(parameters, "reason");
     }
 
     // ------------------------------------------------------------------
@@ -73,6 +73,7 @@ public sealed class Message
     /// </summary>
     public void DispatchEvent(Event evt)
     {
+        ArgumentNullException.ThrowIfNull(evt);
         var p = evt.Params;
 
         // Production wire shape uses "message_state"; some test helpers send

--- a/src/SignalWire/SWAIG/FunctionResult.cs
+++ b/src/SignalWire/SWAIG/FunctionResult.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
 namespace SignalWire.SWAIG;
@@ -52,6 +53,7 @@ public class FunctionResult
 
     public FunctionResult AddActions(IEnumerable<Dictionary<string, object>> actions)
     {
+        ArgumentNullException.ThrowIfNull(actions);
         foreach (var action in actions)
         {
             _actions.Add(action);
@@ -229,7 +231,7 @@ public class FunctionResult
         return this;
     }
 
-    public FunctionResult RemoveGlobalData(List<string> keys)
+    public FunctionResult RemoveGlobalData(IReadOnlyList<string> keys)
     {
         // Python parity: add_action("unset_global_data", keys) — the action key
         // is "unset_global_data" and its value is the bare key list. No
@@ -239,7 +241,7 @@ public class FunctionResult
     }
 
     /// <summary>
-    /// Single-key overload of <see cref="RemoveGlobalData(List{string})"/>.
+    /// Single-key overload of <see cref="RemoveGlobalData(IReadOnlyList{string})"/>.
     /// </summary>
     /// <remarks>
     /// Python's <c>remove_global_data(keys: Union[str, List[str]])</c> accepts a
@@ -260,7 +262,7 @@ public class FunctionResult
         return this;
     }
 
-    public FunctionResult RemoveMetadata(List<string> keys)
+    public FunctionResult RemoveMetadata(IReadOnlyList<string> keys)
     {
         // Python parity: add_action("unset_meta_data", keys) — bare key list under
         // the "unset_meta_data" action key (no {keys: ...} wrapper).
@@ -269,7 +271,7 @@ public class FunctionResult
     }
 
     /// <summary>
-    /// Single-key overload of <see cref="RemoveMetadata(List{string})"/>.
+    /// Single-key overload of <see cref="RemoveMetadata(IReadOnlyList{string})"/>.
     /// </summary>
     /// <remarks>
     /// Python's <c>remove_metadata(keys: Union[str, List[str]])</c> accepts a bare
@@ -476,6 +478,7 @@ public class FunctionResult
     /// emitted (Python emits them unconditionally); the remaining parameters are
     /// emitted only when set.
     /// </remarks>
+    [SuppressMessage("Usage", "CA1054", Justification = "URL is a wire string sent verbatim to the SignalWire API")]
     public FunctionResult RecordCall(
         string controlId = "",
         bool stereo = false,
@@ -526,6 +529,7 @@ public class FunctionResult
     /// or <paramref name="direction"/> is not one of <c>speak</c>/<c>listen</c>/<c>both</c>
     /// (parity with Python's <c>ValueError</c>).
     /// </exception>
+    [SuppressMessage("Usage", "CA1054", Justification = "URL is a wire string sent verbatim to the SignalWire API")]
     public FunctionResult RecordCall(
         string controlId = "",
         bool stereo = false,
@@ -613,7 +617,7 @@ public class FunctionResult
     // Speech & AI
     // ------------------------------------------------------------------
 
-    public FunctionResult AddDynamicHints(List<object> hints)
+    public FunctionResult AddDynamicHints(IReadOnlyList<object> hints)
     {
         _actions.Add(new Dictionary<string, object> { ["add_dynamic_hints"] = hints });
         return this;
@@ -652,7 +656,7 @@ public class FunctionResult
     /// reshaping. (The previous <c>Dictionary&lt;string,bool&gt;</c> shape both
     /// changed the signature AND lost caller-controlled key ordering / extra keys.)
     /// </remarks>
-    public FunctionResult ToggleFunctions(List<Dictionary<string, object>> functionToggles)
+    public FunctionResult ToggleFunctions(IReadOnlyList<Dictionary<string, object>> functionToggles)
     {
         _actions.Add(new Dictionary<string, object> { ["toggle_functions"] = functionToggles });
         return this;
@@ -784,6 +788,7 @@ public class FunctionResult
     /// if <paramref name="maxParticipants"/> is not in 1..=250, or if
     /// <paramref name="name"/> is empty/whitespace.
     /// </exception>
+    [SuppressMessage("Usage", "CA1054", Justification = "URL is a wire string sent verbatim to the SignalWire API")]
     public FunctionResult JoinConference(
         string name,
         bool muted = false,
@@ -940,6 +945,7 @@ public class FunctionResult
     /// <c>sip_refer</c> verb (params <c>{to_uri}</c>) is wrapped in a SWML document
     /// and emitted under the <c>SWML</c> action key.
     /// </remarks>
+    [SuppressMessage("Usage", "CA1054", Justification = "URL is a wire string sent verbatim to the SignalWire API")]
     public FunctionResult SipRefer(string toUri) =>
         EmitSwmlVerb("sip_refer", new Dictionary<string, object> { ["to_uri"] = toUri });
 
@@ -969,6 +975,7 @@ public class FunctionResult
     /// Python's <c>ValueError</c>); <paramref name="direction"/>/<paramref name="codec"/>
     /// are closed-set enums and so cannot be invalid.
     /// </exception>
+    [SuppressMessage("Usage", "CA1054", Justification = "URL is a wire string sent verbatim to the SignalWire API")]
     public FunctionResult Tap(
         string uri,
         string controlId = "",
@@ -1016,6 +1023,7 @@ public class FunctionResult
     /// <paramref name="rtpPtime"/> is not a positive integer (parity with Python's
     /// <c>ValueError</c>).
     /// </exception>
+    [SuppressMessage("Usage", "CA1054", Justification = "URL is a wire string sent verbatim to the SignalWire API")]
     public FunctionResult Tap(
         string uri,
         string controlId = "",
@@ -1101,8 +1109,8 @@ public class FunctionResult
         string toNumber,
         string fromNumber,
         string? body = null,
-        List<string>? media = null,
-        List<string>? tags = null,
+        IReadOnlyList<string>? media = null,
+        IReadOnlyList<string>? tags = null,
         string? region = null)
     {
         // At least body or media must be provided.
@@ -1152,6 +1160,7 @@ public class FunctionResult
     /// </param>
     /// <param name="parameters">Name/value pairs forwarded to the payment connector.</param>
     /// <param name="prompts">Custom prompt configurations (see <see cref="CreatePaymentPrompt"/>).</param>
+    [SuppressMessage("Usage", "CA1054", Justification = "URL is a wire string sent verbatim to the SignalWire API")]
     public FunctionResult Pay(
         string paymentConnectorUrl,
         string inputMethod = "dtmf",
@@ -1169,8 +1178,8 @@ public class FunctionResult
         string voice = "woman",
         string? description = null,
         string validCardTypes = "visa mastercard amex",
-        List<Dictionary<string, string>>? parameters = null,
-        List<Dictionary<string, object>>? prompts = null,
+        IReadOnlyList<Dictionary<string, string>>? parameters = null,
+        IReadOnlyList<Dictionary<string, object>>? prompts = null,
         string? aiResponse = "The payment status is ${pay_result}, do not mention anything else about collecting payment if successful.")
     {
         // postal_code defaults to bool true (Python: postal_code=True).
@@ -1350,7 +1359,7 @@ public class FunctionResult
     /// <param name="actions">Actions with <c>type</c>/<c>phrase</c> keys (see <see cref="CreatePaymentAction"/>).</param>
     public static Dictionary<string, object> CreatePaymentPrompt(
         string forSituation,
-        List<Dictionary<string, string>> actions,
+        IReadOnlyList<Dictionary<string, string>> actions,
         string? cardType = null,
         string? errorType = null)
     {

--- a/src/SignalWire/SWAIG/JoinConferenceOptions.cs
+++ b/src/SignalWire/SWAIG/JoinConferenceOptions.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace SignalWire.SWAIG;
 
 /// <summary>
@@ -31,7 +33,7 @@ namespace SignalWire.SWAIG;
 public sealed record JoinConferenceOptions
 {
     /// <summary>Whether to join muted. Python default: <c>False</c>.</summary>
-    public bool Muted { get; init; } = false;
+    public bool Muted { get; init; }
 
     /// <summary>Beep behaviour. Python default: <c>"true"</c>.</summary>
     public ConferenceBeep Beep { get; init; } = ConferenceBeep.True;
@@ -40,10 +42,11 @@ public sealed record JoinConferenceOptions
     public bool StartOnEnter { get; init; } = true;
 
     /// <summary>Whether the conference ends when this participant exits. Python default: <c>False</c>.</summary>
-    public bool EndOnExit { get; init; } = false;
+    public bool EndOnExit { get; init; }
 
     /// <summary>SWML URL for hold music. Python default: <c>None</c>.</summary>
-    public string? WaitUrl { get; init; } = null;
+    [SuppressMessage("Usage", "CA1056", Justification = "URL is a wire string sent verbatim to the SignalWire API")]
+    public string? WaitUrl { get; init; }
 
     /// <summary>Maximum participants (1..=250). Python default: <c>250</c>.</summary>
     public int MaxParticipants { get; init; } = 250;
@@ -52,25 +55,27 @@ public sealed record JoinConferenceOptions
     public ConferenceRecord Record { get; init; } = ConferenceRecord.DoNotRecord;
 
     /// <summary>Conference region. Python default: <c>None</c>.</summary>
-    public string? Region { get; init; } = null;
+    public string? Region { get; init; }
 
     /// <summary>Silence-trim mode. Python default: <c>"trim-silence"</c>.</summary>
     public ConferenceTrim Trim { get; init; } = ConferenceTrim.TrimSilence;
 
     /// <summary>SWML Call ID / CXML CallSid for coaching. Python default: <c>None</c>.</summary>
-    public string? Coach { get; init; } = null;
+    public string? Coach { get; init; }
 
     /// <summary>Events to report. Python default: <c>None</c>.</summary>
-    public string? StatusCallbackEvent { get; init; } = null;
+    public string? StatusCallbackEvent { get; init; }
 
     /// <summary>URL for status callbacks. Python default: <c>None</c>.</summary>
-    public string? StatusCallback { get; init; } = null;
+    [SuppressMessage("Usage", "CA1056", Justification = "URL is a wire string sent verbatim to the SignalWire API")]
+    public string? StatusCallback { get; init; }
 
     /// <summary>HTTP method for status callbacks. Python default: <c>"POST"</c>.</summary>
     public CallbackMethod StatusCallbackMethod { get; init; } = CallbackMethod.Post;
 
     /// <summary>URL for recording status callbacks. Python default: <c>None</c>.</summary>
-    public string? RecordingStatusCallback { get; init; } = null;
+    [SuppressMessage("Usage", "CA1056", Justification = "URL is a wire string sent verbatim to the SignalWire API")]
+    public string? RecordingStatusCallback { get; init; }
 
     /// <summary>HTTP method for recording status callbacks. Python default: <c>"POST"</c>.</summary>
     public CallbackMethod RecordingStatusCallbackMethod { get; init; } = CallbackMethod.Post;
@@ -79,5 +84,5 @@ public sealed record JoinConferenceOptions
     public string RecordingStatusCallbackEvent { get; init; } = "completed";
 
     /// <summary>Switch payload (object {} or array []). Python default: <c>None</c>.</summary>
-    public object? Result { get; init; } = null;
+    public object? Result { get; init; }
 }

--- a/src/SignalWire/SWAIG/ParameterSchema.cs
+++ b/src/SignalWire/SWAIG/ParameterSchema.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace SignalWire.SWAIG;
@@ -87,6 +88,7 @@ public sealed class ParameterSchema
     /// <param name="defaultValue">Optional JSON-Schema <c>default</c>.</param>
     /// <param name="format">Optional JSON-Schema <c>format</c> hint (e.g. <c>"date"</c>).</param>
     /// <param name="enumValues">Optional closed set of allowed string values.</param>
+    [SuppressMessage("Naming", "CA1720", Justification = "Fluent builder verb names the JSON-Schema type it emits (\"string\"); part of the typed convenience DSL surface")]
     public ParameterSchema String(
         string name,
         string? description = null,
@@ -106,6 +108,7 @@ public sealed class ParameterSchema
         AddScalar(name, "number", description, required, defaultValue, format, null);
 
     /// <summary>Add an <c>integer</c> property.</summary>
+    [SuppressMessage("Naming", "CA1720", Justification = "Fluent builder verb names the JSON-Schema type it emits (\"integer\"); part of the typed convenience DSL surface")]
     public ParameterSchema Integer(
         string name,
         string? description = null,
@@ -189,6 +192,7 @@ public sealed class ParameterSchema
         string? description = null,
         bool required = false)
     {
+        ArgumentNullException.ThrowIfNull(itemSchema);
         var items = new Dictionary<string, object>
         {
             ["type"] = "object",
@@ -202,13 +206,17 @@ public sealed class ParameterSchema
     /// <see cref="ParameterSchema"/>. Emits
     /// <c>{"type":"object","properties":{…}}</c>.
     /// </summary>
+    [SuppressMessage("Naming", "CA1720", Justification = "Fluent builder verb names the JSON-Schema type it emits (\"object\"); part of the typed convenience DSL surface")]
     public ParameterSchema Object(
         string name,
         ParameterSchema schema,
         string? description = null,
-        bool required = false) =>
-        AddProperty(name, "object", description, required,
+        bool required = false)
+    {
+        ArgumentNullException.ThrowIfNull(schema);
+        return AddProperty(name, "object", description, required,
             prop => prop["properties"] = schema.Build());
+    }
 
     /// <summary>
     /// Mark one or more already-declared properties required by setting the
@@ -218,6 +226,7 @@ public sealed class ParameterSchema
     /// <exception cref="ArgumentException">If a named property was not declared.</exception>
     public ParameterSchema Required(params string[] names)
     {
+        ArgumentNullException.ThrowIfNull(names);
         foreach (var name in names)
         {
             if (!_properties.TryGetValue(name, out var prop))
@@ -325,7 +334,7 @@ public sealed class ParameterSchema
     /// </summary>
     private static List<string> WireNamesOf(Type enumType)
     {
-        if (enumType is null) throw new ArgumentNullException(nameof(enumType));
+        ArgumentNullException.ThrowIfNull(enumType);
         if (!enumType.IsEnum)
         {
             throw new ArgumentException(

--- a/src/SignalWire/SWML/Document.cs
+++ b/src/SignalWire/SWML/Document.cs
@@ -52,7 +52,7 @@ public class Document
     /// Get a copy of the verbs for a section.
     /// Returns an empty list if the section does not exist.
     /// </summary>
-    public List<Dictionary<string, object?>> GetVerbs(string section = "main")
+    public IReadOnlyList<Dictionary<string, object?>> GetVerbs(string section = "main")
     {
         if (_sections.TryGetValue(section, out var verbs))
         {
@@ -70,21 +70,21 @@ public class Document
     /// <summary>Append a verb to a named section.</summary>
     public void AddVerbToSection(string section, string verbName, object? config)
     {
-        if (!_sections.ContainsKey(section))
+        if (!_sections.TryGetValue(section, out var verbs))
         {
             throw new InvalidOperationException($"Section '{section}' does not exist");
         }
-        _sections[section].Add(new Dictionary<string, object?> { [verbName] = config });
+        verbs.Add(new Dictionary<string, object?> { [verbName] = config });
     }
 
     /// <summary>Append a pre-formatted verb hash to a section.</summary>
     public void AddRawVerb(string section, Dictionary<string, object?> verbHash)
     {
-        if (!_sections.ContainsKey(section))
+        if (!_sections.TryGetValue(section, out var verbs))
         {
             throw new InvalidOperationException($"Section '{section}' does not exist");
         }
-        _sections[section].Add(verbHash);
+        verbs.Add(verbHash);
     }
 
     /// <summary>Clear all verbs in a section (keeps the section itself).</summary>

--- a/src/SignalWire/SWML/SWMLBuilder.cs
+++ b/src/SignalWire/SWML/SWMLBuilder.cs
@@ -7,6 +7,7 @@
 // Each verb method returns this for chaining: build().Answer().Ai(...).Hangup().
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
 namespace SignalWire.SWML;
@@ -43,9 +44,10 @@ public class SWMLBuilder
 
     /// <summary>Add an ``ai`` verb. (Python parity:
     /// ``SWMLBuilder.ai(prompt_text, prompt_pom, post_prompt, post_prompt_url, swaig, ...)``.)</summary>
+    [SuppressMessage("Usage", "CA1054", Justification = "URL is a wire string sent verbatim to the SignalWire API as a SWML field value.")]
     public SWMLBuilder Ai(
         string? promptText = null,
-        List<Dictionary<string, object>>? promptPom = null,
+        IReadOnlyList<Dictionary<string, object>>? promptPom = null,
         string? postPrompt = null,
         string? postPromptUrl = null,
         Dictionary<string, object>? swaig = null,
@@ -73,9 +75,10 @@ public class SWMLBuilder
 
     /// <summary>Add a ``play`` verb. (Python parity:
     /// ``SWMLBuilder.play(url, urls, volume, say_text, say_voice, say_language)``.)</summary>
+    [SuppressMessage("Usage", "CA1054", Justification = "URL is a wire string sent verbatim to the SignalWire API as a SWML field value.")]
     public SWMLBuilder Play(
         string? url = null,
-        List<string>? urls = null,
+        IReadOnlyList<string>? urls = null,
         double? volume = null,
         string? sayText = null,
         string? sayVoice = null,

--- a/src/SignalWire/SWML/Schema.cs
+++ b/src/SignalWire/SWML/Schema.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text.Json;
 
@@ -14,16 +15,31 @@ public sealed record VerbInfo(string Name, string SchemaName, JsonElement Defini
 /// <summary>Validation error raised by SchemaUtils.ValidateVerb when a
 /// verb config violates its schema. (Python parity:
 /// ``signalwire.utils.schema_utils.SchemaValidationError``.)</summary>
+[SuppressMessage("Naming", "CA1710", Justification = "Type name matches the cross-port surface (Python SchemaValidationError); renaming to *Exception would break parity.")]
 public class SchemaValidationError : Exception
 {
-    public string VerbName { get; }
-    public List<string> Errors { get; }
+    public string VerbName { get; } = "";
+    public IReadOnlyList<string> Errors { get; } = Array.Empty<string>();
 
-    public SchemaValidationError(string verbName, List<string> errors)
-        : base($"Schema validation failed for verb '{verbName}': {string.Join("; ", errors)}")
+    public SchemaValidationError(string verbName, IReadOnlyList<string> errors)
+        : base($"Schema validation failed for verb '{verbName}': {string.Join("; ", errors ?? Array.Empty<string>())}")
     {
         VerbName = verbName;
-        Errors = errors;
+        Errors = errors ?? Array.Empty<string>();
+    }
+
+    public SchemaValidationError()
+    {
+    }
+
+    public SchemaValidationError(string message)
+        : base(message)
+    {
+    }
+
+    public SchemaValidationError(string message, Exception innerException)
+        : base(message, innerException)
+    {
     }
 }
 
@@ -44,6 +60,7 @@ public sealed class Schema
     }
 
     /// <summary>Thread-safe singleton accessor.</summary>
+    [SuppressMessage("Maintainability", "CA1508", Justification = "Double-checked locking; the analyzer cannot model that Reset() (used by tests) nulls _instance from another method, so its always-null claim is a false positive.")]
     public static Schema Instance
     {
         get
@@ -70,7 +87,7 @@ public sealed class Schema
     public bool IsValidVerb(string name) => _verbs.ContainsKey(name);
 
     /// <summary>Get a sorted list of all verb names.</summary>
-    public List<string> GetVerbNames()
+    public IReadOnlyList<string> GetVerbNames()
     {
         var names = _verbs.Keys.ToList();
         names.Sort(StringComparer.Ordinal);
@@ -88,12 +105,13 @@ public sealed class Schema
 
     /// <summary>Alias of <see cref="GetVerbNames"/>. (Python parity:
     /// ``SchemaUtils.get_all_verb_names``.)</summary>
-    public List<string> GetAllVerbNames() => GetVerbNames();
+    public IReadOnlyList<string> GetAllVerbNames() => GetVerbNames();
 
     /// <summary>Public load-schema accessor. Returns the embedded SWML
     /// schema as a Dictionary&lt;string, JsonElement&gt;. Empty dict
     /// when the schema can't be loaded. (Python parity:
     /// ``SchemaUtils.load_schema``.)</summary>
+    [SuppressMessage("Performance", "CA1822", Justification = "Instance accessor matching the cross-port surface (Python SchemaUtils.load_schema); kept non-static so callers reach it via Schema.Instance.")]
     public Dictionary<string, JsonElement> LoadSchemaPublic()
     {
         var assembly = Assembly.GetExecutingAssembly();

--- a/src/SignalWire/SWML/Service.cs
+++ b/src/SignalWire/SWML/Service.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Net;
 using System.Security.Cryptography;
 using System.Text;
@@ -55,7 +57,11 @@ public class Service
 
     // SWAIG tool registry — lifted from AgentBase so any Service (sidecar,
     // non-agent verb host) can register and dispatch SWAIG functions.
+    [SuppressMessage("Design", "CA1051", Justification = "Mutable SWAIG registry shared with the AgentBase subclass (reassigned during clone); intentional protected field.")]
     protected Dictionary<string, Dictionary<string, object>> _tools = new();
+
+    [SuppressMessage("Design", "CA1051", Justification = "Mutable SWAIG registration-order list shared with the AgentBase subclass (reassigned during clone); intentional protected field.")]
+    [SuppressMessage("Design", "CA1002", Justification = "Internal mutable backing list shared with the AgentBase subclass; not a public surface return type.")]
     protected List<string> _toolOrder = new();
 
     public string Name { get; }
@@ -66,6 +72,7 @@ public class Service
 
     public Service(ServiceOptions options)
     {
+        ArgumentNullException.ThrowIfNull(options);
         Name = options.Name;
 
         var route = options.Route.TrimEnd('/');
@@ -171,6 +178,7 @@ public class Service
     // ------------------------------------------------------------------
 
     /// <summary>Get the Basic Auth credentials as a tuple.</summary>
+    [SuppressMessage("Design", "CA1024", Justification = "get_* accessor matches the cross-port surface (Python get_basic_auth_credentials).")]
     public (string User, string Password) GetBasicAuthCredentials()
     {
         return (_basicAuthUser, _basicAuthPassword);
@@ -190,7 +198,7 @@ public class Service
         {
             source = "environment";
         }
-        else if (_basicAuthUser.StartsWith("user_") && _basicAuthPassword.Length > 20)
+        else if (_basicAuthUser.StartsWith("user_", StringComparison.Ordinal) && _basicAuthPassword.Length > 20)
         {
             source = "generated";
         }
@@ -216,6 +224,7 @@ public class Service
     }
 
     /// <summary>Build the full URL for this service.</summary>
+    [SuppressMessage("Usage", "CA1055", Justification = "URL is a wire string sent verbatim to the SignalWire API / used as a config value.")]
     public string GetFullUrl(bool includeAuth = false)
     {
         var auth = includeAuth
@@ -285,6 +294,9 @@ public class Service
         Dictionary<string, string> headers,
         string? body)
     {
+        ArgumentNullException.ThrowIfNull(path);
+        ArgumentNullException.ThrowIfNull(headers);
+
         // Health/ready: no auth required
         if (path == "/health")
         {
@@ -393,15 +405,26 @@ public class Service
         Func<Dictionary<string, object>, Dictionary<string, object?>, FunctionResult> handler,
         bool secure = false)
     {
+        ArgumentNullException.ThrowIfNull(parameters);
+        var (properties, required) = NormalizeParameters(parameters);
+        var argument = new Dictionary<string, object>
+        {
+            ["type"] = "object",
+            ["properties"] = properties,
+        };
+        // Emit the top-level JSON-Schema `required` array (the form the model +
+        // validator expect) only when non-empty — matching the Python reference,
+        // which omits the key for an empty required list (swaig_function.py:128).
+        if (required.Count > 0)
+        {
+            argument["required"] = required;
+        }
+
         _tools[name] = new Dictionary<string, object>
         {
             ["function"] = name,
             ["purpose"] = description,
-            ["argument"] = new Dictionary<string, object>
-            {
-                ["type"] = "object",
-                ["properties"] = parameters,
-            },
+            ["argument"] = argument,
             ["_handler"] = handler,
             ["_secure"] = secure,
         };
@@ -412,9 +435,46 @@ public class Service
         return this;
     }
 
+    /// <summary>
+    /// Normalize a tool's flat property map into (properties, required).
+    /// Skills mark a parameter required by setting <c>["required"] = true</c>
+    /// inside the property object (the ergonomic per-property idiom). JSON
+    /// Schema — and the Python reference — express requiredness as a top-level
+    /// <c>required: [...]</c> array on the parameters object, not a per-property
+    /// flag. This lifts each property's <c>"required": true</c> into that array
+    /// (in declared order) and strips the flag from the property, so the emitted
+    /// <c>argument</c> is standard JSON Schema and byte-matches the reference.
+    /// A property without the flag (or <c>"required": false</c>) is optional.
+    /// </summary>
+    private static (Dictionary<string, object> Properties, List<string> Required) NormalizeParameters(
+        Dictionary<string, object> parameters)
+    {
+        var properties = new Dictionary<string, object>(parameters.Count);
+        var required = new List<string>();
+        foreach (var (key, value) in parameters)
+        {
+            if (value is Dictionary<string, object> prop)
+            {
+                var copy = new Dictionary<string, object>(prop);
+                if (copy.TryGetValue("required", out var req) && req is true)
+                {
+                    required.Add(key);
+                }
+                copy.Remove("required");
+                properties[key] = copy;
+            }
+            else
+            {
+                properties[key] = value;
+            }
+        }
+        return (properties, required);
+    }
+
     /// <summary>Register a raw SWAIG function definition (e.g. DataMap tools).</summary>
     public virtual Service RegisterSwaigFunction(Dictionary<string, object> funcDef)
     {
+        ArgumentNullException.ThrowIfNull(funcDef);
         var name = funcDef.TryGetValue("function", out var n) ? n as string ?? "" : "";
         if (name.Length == 0)
         {
@@ -455,8 +515,9 @@ public class Service
     }
 
     /// <summary>Register multiple tool definitions at once.</summary>
-    public virtual Service DefineTools(List<Dictionary<string, object>> toolDefs)
+    public virtual Service DefineTools(IReadOnlyList<Dictionary<string, object>> toolDefs)
     {
+        ArgumentNullException.ThrowIfNull(toolDefs);
         foreach (var def in toolDefs)
         {
             RegisterSwaigFunction(def);
@@ -702,7 +763,7 @@ public class Service
         if (sipUri.StartsWith("sip:", StringComparison.OrdinalIgnoreCase))
         {
             var afterPrefix = sipUri[4..];
-            var atIdx = afterPrefix.IndexOf('@');
+            var atIdx = afterPrefix.IndexOf('@', StringComparison.Ordinal);
             username = atIdx >= 0 ? afterPrefix[..atIdx] : afterPrefix;
         }
         else
@@ -727,6 +788,7 @@ public class Service
     /// Detect or construct the proxy URL base from request headers.
     /// Priority: SWML_PROXY_URL_BASE env > X-Forwarded-Proto+Host > X-Original-URL > fallback.
     /// </summary>
+    [SuppressMessage("Usage", "CA1055", Justification = "URL is a wire string sent verbatim to the SignalWire API / used as a config value.")]
     public string GetProxyUrlBase(Dictionary<string, string>? headers = null)
     {
         // 1. Explicit env var
@@ -786,7 +848,7 @@ public class Service
         }
 
         var decodedStr = Encoding.UTF8.GetString(decoded);
-        var colonIdx = decodedStr.IndexOf(':');
+        var colonIdx = decodedStr.IndexOf(':', StringComparison.Ordinal);
         if (colonIdx < 0)
         {
             return false;
@@ -828,6 +890,7 @@ public class Service
     }
 
     /// <summary>Generate cryptographically secure random hex string.</summary>
+    [SuppressMessage("Globalization", "CA1308", Justification = "lowercase hex is the convention/wire form for credential tokens")]
     private static string RandomHex(int bytes)
     {
         var buffer = new byte[bytes];
@@ -836,6 +899,7 @@ public class Service
     }
 
     /// <summary>Case-insensitive header lookup.</summary>
+    [SuppressMessage("Globalization", "CA1308", Justification = "lowercase is the conventional wire form for HTTP header names")]
     private static string? GetHeaderCaseInsensitive(Dictionary<string, string> headers, string name)
     {
         if (headers.TryGetValue(name, out var value))
@@ -902,6 +966,7 @@ public class Service
     }
 
     /// <summary>Plain-HTTP server backed by the BCL HttpListener.</summary>
+    [SuppressMessage("Design", "CA1031", Justification = "Per-request handler boundary and best-effort cleanup: a single failed request (or its error/close path) must not crash the blocking server loop.")]
     private void RunHttp(CancellationToken cancellationToken)
     {
         var prefix = $"http://{(Host == "0.0.0.0" ? "+" : Host)}:{Port}/";
@@ -997,9 +1062,11 @@ public class Service
     /// adapted to the same <see cref="HandleRequest"/> contract used by the
     /// HTTP path, so SWML/SWAIG behavior is identical over either transport.
     /// </summary>
+    [SuppressMessage("Design", "CA1031", Justification = "Per-request handler boundary and best-effort header writes: a single failed request must not crash the Kestrel pipeline; the failure is surfaced as a 500.")]
+    [SuppressMessage("Reliability", "CA2025", Justification = "app.RunAsync(...).GetResult() blocks until the server stops, so serverCert is alive for the entire Kestrel lifetime and the 'using' disposes it only after the task has completed.")]
     private void RunHttps(SslSettings ssl, CancellationToken cancellationToken)
     {
-        var serverCert = LoadServerCertificate(ssl);
+        using var serverCert = LoadServerCertificate(ssl);
 
         var builder = Microsoft.AspNetCore.Builder.WebApplication.CreateSlimBuilder();
         builder.Logging.ClearProviders();
@@ -1102,8 +1169,10 @@ public class Service
 
         public static SslSettings FromEnvironment()
         {
-            var flag = (Environment.GetEnvironmentVariable("SWML_SSL_ENABLED") ?? "").Trim().ToLowerInvariant();
-            var enabled = flag is "true" or "1" or "yes";
+            var flag = (Environment.GetEnvironmentVariable("SWML_SSL_ENABLED") ?? "").Trim();
+            var enabled = flag.Equals("true", StringComparison.OrdinalIgnoreCase)
+                || flag.Equals("1", StringComparison.Ordinal)
+                || flag.Equals("yes", StringComparison.OrdinalIgnoreCase);
             var cert = Environment.GetEnvironmentVariable("SWML_SSL_CERT_PATH");
             var key = Environment.GetEnvironmentVariable("SWML_SSL_KEY_PATH");
 

--- a/src/SignalWire/SWML/SwmlRenderer.cs
+++ b/src/SignalWire/SWML/SwmlRenderer.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
 namespace SignalWire.SWML;
@@ -19,12 +20,13 @@ public static class SwmlRenderer
 {
     /// <summary>Generate a complete SWML document with AI configuration.
     /// (Python parity: ``SwmlRenderer.render_swml``.)</summary>
+    [SuppressMessage("Usage", "CA1054", Justification = "URL is a wire string sent verbatim to the SignalWire API as a SWML/SWAIG field value.")]
     public static string RenderSwml(
         object prompt,
         Service service,
         string? postPrompt = null,
         string? postPromptUrl = null,
-        List<Dictionary<string, object>>? swaigFunctions = null,
+        IReadOnlyList<Dictionary<string, object>>? swaigFunctions = null,
         string? startupHookUrl = null,
         string? hangupHookUrl = null,
         bool promptIsPom = false,
@@ -36,6 +38,8 @@ public static class SwmlRenderer
         string format = "json",
         string? defaultWebhookUrl = null)
     {
+        ArgumentNullException.ThrowIfNull(service);
+        ArgumentNullException.ThrowIfNull(format);
         var builder = new SWMLBuilder(service);
         builder.Reset();
 
@@ -101,9 +105,11 @@ public static class SwmlRenderer
     public static string RenderFunctionResponseSwml(
         string responseText,
         Service service,
-        List<Dictionary<string, object>>? actions = null,
+        IReadOnlyList<Dictionary<string, object>>? actions = null,
         string format = "json")
     {
+        ArgumentNullException.ThrowIfNull(service);
+        ArgumentNullException.ThrowIfNull(format);
         service.Document.Reset();
 
         if (!string.IsNullOrEmpty(responseText))

--- a/src/SignalWire/Security/SessionManager.cs
+++ b/src/SignalWire/Security/SessionManager.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -28,6 +29,7 @@ public sealed class SessionManager
     /// <summary>
     /// Create or confirm a session, returning the call ID.
     /// </summary>
+    [SuppressMessage("Performance", "CA1822", Justification = "Instance method matches the cross-port SessionManager surface; binding it to the instance is intentional.")]
     public string CreateSession(string? callId = null)
     {
         return callId ?? Guid.NewGuid().ToString();
@@ -61,12 +63,18 @@ public sealed class SessionManager
     /// <returns><c>true</c> if the token is valid and not expired.</returns>
     public bool ValidateToken(string functionName, string callId, string token)
     {
+        ArgumentNullException.ThrowIfNull(token);
+
         string decoded;
         try
         {
             decoded = Base64UrlDecode(token);
         }
-        catch
+        catch (FormatException)
+        {
+            return false;
+        }
+        catch (DecoderFallbackException)
         {
             return false;
         }
@@ -121,6 +129,7 @@ public sealed class SessionManager
     // Private helpers
     // ------------------------------------------------------------------
 
+    [SuppressMessage("Globalization", "CA1308", Justification = "Lowercase hex is the on-the-wire token signature form; the digest is sent and compared verbatim.")]
     private string ComputeHmac(string message)
     {
         var messageBytes = Encoding.UTF8.GetBytes(message);
@@ -135,6 +144,7 @@ public sealed class SessionManager
         return CryptographicOperations.FixedTimeEquals(aBytes, bBytes);
     }
 
+    [SuppressMessage("Globalization", "CA1308", Justification = "Lowercase hex is the on-the-wire nonce form embedded in the token; produced and compared verbatim.")]
     private static string RandomHex(int bytes)
     {
         var buffer = new byte[bytes];

--- a/src/SignalWire/Security/WebhookValidationMiddleware.cs
+++ b/src/SignalWire/Security/WebhookValidationMiddleware.cs
@@ -30,6 +30,8 @@
 // The class is small by design — see WebhookValidator for the actual
 // crypto. This is just the wire-shape glue.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace SignalWire.Security;
 
 /// <summary>
@@ -152,6 +154,7 @@ public sealed class WebhookValidationMiddleware
     ///     local construction.</item>
     /// </list>
     /// </summary>
+    [SuppressMessage("Usage", "CA1055", Justification = "Returns a URL wire string that is fed verbatim to WebhookValidator and compared against the platform's signed string; a Uri round-trip could normalize away the exact bytes the signature covers.")]
     public string ReconstructUrl(
         Dictionary<string, string> headers,
         string path,
@@ -209,6 +212,7 @@ public sealed class WebhookValidationMiddleware
         return (403, headers, "");
     }
 
+    [SuppressMessage("Globalization", "CA1308", Justification = "HTTP header names are matched in their conventional lowercase wire form; the value is used only as a dictionary key, never sent.")]
     private static string? GetHeaderCaseInsensitive(
         Dictionary<string, string>? headers, string name)
     {

--- a/src/SignalWire/Security/WebhookValidator.cs
+++ b/src/SignalWire/Security/WebhookValidator.cs
@@ -18,6 +18,7 @@
 // logged, never echoed in error messages, and never included in the response.
 
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
@@ -34,6 +35,8 @@ namespace SignalWire.Security;
 /// </summary>
 public static class WebhookValidator
 {
+    private static readonly char[] AuthorityTerminators = { '/', '?', '#' };
+
     // ----------------------------------------------------------------------
     // Public API
     // ----------------------------------------------------------------------
@@ -67,6 +70,7 @@ public static class WebhookValidator
     /// <exception cref="ArgumentException">
     /// Thrown when <paramref name="signingKey"/> is null or empty.
     /// </exception>
+    [SuppressMessage("Usage", "CA1054", Justification = "URL is the wire string the platform signed verbatim; it is concatenated byte-for-byte into the HMAC message, so a Uri round-trip could alter the signed bytes.")]
     public static bool ValidateWebhookSignature(
         string signingKey,
         string? signature,
@@ -145,6 +149,7 @@ public static class WebhookValidator
     /// <paramref name="paramsOrRawBody"/> is neither a string nor a
     /// dictionary/list of params.
     /// </exception>
+    [SuppressMessage("Usage", "CA1054", Justification = "URL is the wire string the platform signed verbatim; it is concatenated byte-for-byte into the HMAC message, so a Uri round-trip could alter the signed bytes.")]
     public static bool ValidateRequest(
         string signingKey,
         string? signature,
@@ -294,6 +299,8 @@ public static class WebhookValidator
     // ----------------------------------------------------------------------
 
     /// <summary>Scheme-A digest: lowercase hex of HMAC-SHA1.</summary>
+    [SuppressMessage("Security", "CA5350", Justification = "HMAC-SHA1 is mandated by the SignalWire webhook signature contract (porting-sdk/webhooks.md); the algorithm is fixed by the wire protocol and cross-port test vectors, not a free choice.")]
+    [SuppressMessage("Globalization", "CA1308", Justification = "Lowercase hex is the Scheme-A digest form sent on the wire and compared verbatim against the X-SignalWire-Signature header.")]
     private static string HexHmacSha1(string key, string message)
     {
         var keyBytes = Encoding.UTF8.GetBytes(key);
@@ -303,6 +310,7 @@ public static class WebhookValidator
     }
 
     /// <summary>Scheme-B digest: standard base64 of HMAC-SHA1.</summary>
+    [SuppressMessage("Security", "CA5350", Justification = "HMAC-SHA1 is mandated by the SignalWire/cXML webhook signature contract (porting-sdk/webhooks.md); the algorithm is fixed by the wire protocol and cross-port test vectors, not a free choice.")]
     private static string Base64HmacSha1(string key, string message)
     {
         var keyBytes = Encoding.UTF8.GetBytes(key);
@@ -315,6 +323,7 @@ public static class WebhookValidator
     /// Constant-time string compare. Returns false on any unexpected error so
     /// malformed inputs never throw.
     /// </summary>
+    [SuppressMessage("Design", "CA1031", Justification = "Constant-time compare must never throw on malformed input; any failure is treated as a non-match (returns false) to avoid leaking branch information.")]
     private static bool SafeEquals(string a, string b)
     {
         try
@@ -367,6 +376,7 @@ public static class WebhookValidator
     /// Best-effort parse of an <c>application/x-www-form-urlencoded</c> body.
     /// Returns an empty list if the body doesn't decode as form data.
     /// </summary>
+    [SuppressMessage("Design", "CA1031", Justification = "Best-effort form parse: any decode failure yields an empty param list so a malformed body never throws into the validator.")]
     private static List<KeyValuePair<string, string>> ParseFormBody(string rawBody)
     {
         var result = new List<KeyValuePair<string, string>>();
@@ -375,7 +385,7 @@ public static class WebhookValidator
             return result;
         }
         // Bail out early if there's no '=' anywhere — definitely not form data.
-        if (!rawBody.Contains('='))
+        if (!rawBody.Contains('=', StringComparison.Ordinal))
         {
             return result;
         }
@@ -385,7 +395,7 @@ public static class WebhookValidator
             foreach (var pair in rawBody.Split('&'))
             {
                 if (pair.Length == 0) continue;
-                var eq = pair.IndexOf('=');
+                var eq = pair.IndexOf('=', StringComparison.Ordinal);
                 string key, value;
                 if (eq < 0)
                 {
@@ -418,6 +428,7 @@ public static class WebhookValidator
     ///   <item>If https + <c>:443</c> / http + <c>:80</c>: input URL AND url with port stripped.</item>
     /// </list>
     /// </summary>
+    [SuppressMessage("Design", "CA1031", Justification = "Best-effort URL parse: an unparseable URL falls back to using the input string as the sole candidate rather than throwing.")]
     private static List<string> CandidateUrls(string url)
     {
         var result = new List<string>();
@@ -442,11 +453,11 @@ public static class WebhookValidator
             return result;
         }
 
-        var scheme = (parsed.Scheme ?? "").ToLowerInvariant();
+        var scheme = (parsed.Scheme ?? "").ToUpperInvariant();
         int? standardPort = scheme switch
         {
-            "http" => 80,
-            "https" => 443,
+            "HTTP" => 80,
+            "HTTPS" => 443,
             _ => null,
         };
 
@@ -494,22 +505,22 @@ public static class WebhookValidator
         var schemeEnd = url.IndexOf("://", StringComparison.Ordinal);
         if (schemeEnd < 0) return false;
         var afterScheme = schemeEnd + 3;
-        var pathStart = url.IndexOfAny(new[] { '/', '?', '#' }, afterScheme);
+        var pathStart = url.IndexOfAny(AuthorityTerminators, afterScheme);
         var authorityEnd = pathStart < 0 ? url.Length : pathStart;
         var authority = url[afterScheme..authorityEnd];
         // IPv6 host: skip the "[...]" segment before looking for ':'.
-        var bracketEnd = authority.IndexOf(']');
+        var bracketEnd = authority.IndexOf(']', StringComparison.Ordinal);
         var searchFrom = bracketEnd >= 0 ? bracketEnd + 1 : 0;
         // Strip userinfo "user:pass@" — port lookup is on the host part only.
         var atSign = authority.IndexOf('@', searchFrom);
         var hostPart = atSign >= 0 ? authority[(atSign + 1)..] : authority[searchFrom..];
-        return hostPart.Contains(':');
+        return hostPart.Contains(':', StringComparison.Ordinal);
     }
 
     private static string BuildUrlWithPort(Uri uri, int port)
     {
         var host = uri.Host;
-        if (host.Contains(':') && !host.StartsWith('['))
+        if (host.Contains(':', StringComparison.Ordinal) && !host.StartsWith('['))
         {
             host = $"[{host}]";
         }
@@ -521,7 +532,7 @@ public static class WebhookValidator
     private static string BuildUrlWithoutPort(Uri uri)
     {
         var host = uri.Host;
-        if (host.Contains(':') && !host.StartsWith('['))
+        if (host.Contains(':', StringComparison.Ordinal) && !host.StartsWith('['))
         {
             host = $"[{host}]";
         }
@@ -536,6 +547,8 @@ public static class WebhookValidator
     /// present and matches. Returns false only when the param is present and
     /// mismatches.
     /// </summary>
+    [SuppressMessage("Design", "CA1031", Justification = "Best-effort URL parse: an unparseable URL means there is no bodySHA256 constraint to enforce, so the check passes rather than throwing.")]
+    [SuppressMessage("Globalization", "CA1308", Justification = "Lowercase hex is the bodySHA256 wire form compared verbatim against the query-param digest.")]
     private static bool CheckBodySha256(string url, string rawBody)
     {
         Uri? parsed;
@@ -562,7 +575,7 @@ public static class WebhookValidator
         foreach (var pair in qstr.Split('&'))
         {
             if (pair.Length == 0) continue;
-            var eq = pair.IndexOf('=');
+            var eq = pair.IndexOf('=', StringComparison.Ordinal);
             string k, v;
             if (eq < 0) { k = pair; v = ""; }
             else { k = pair[..eq]; v = pair[(eq + 1)..]; }

--- a/src/SignalWire/Server/AgentServer.cs
+++ b/src/SignalWire/Server/AgentServer.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
@@ -24,12 +26,23 @@ public partial class AgentServer
 
     private static readonly Dictionary<string, string> MimeTypes = new(StringComparer.OrdinalIgnoreCase)
     {
-        ["html"] = "text/html", ["htm"] = "text/html", ["css"] = "text/css",
-        ["js"] = "application/javascript", ["json"] = "application/json",
-        ["png"] = "image/png", ["jpg"] = "image/jpeg", ["jpeg"] = "image/jpeg",
-        ["gif"] = "image/gif", ["svg"] = "image/svg+xml", ["ico"] = "image/x-icon",
-        ["txt"] = "text/plain", ["pdf"] = "application/pdf", ["xml"] = "application/xml",
-        ["woff"] = "font/woff", ["woff2"] = "font/woff2", ["ttf"] = "font/ttf",
+        ["html"] = "text/html",
+        ["htm"] = "text/html",
+        ["css"] = "text/css",
+        ["js"] = "application/javascript",
+        ["json"] = "application/json",
+        ["png"] = "image/png",
+        ["jpg"] = "image/jpeg",
+        ["jpeg"] = "image/jpeg",
+        ["gif"] = "image/gif",
+        ["svg"] = "image/svg+xml",
+        ["ico"] = "image/x-icon",
+        ["txt"] = "text/plain",
+        ["pdf"] = "application/pdf",
+        ["xml"] = "application/xml",
+        ["woff"] = "font/woff",
+        ["woff2"] = "font/woff2",
+        ["ttf"] = "font/ttf",
         ["eot"] = "application/vnd.ms-fontobject",
     };
 
@@ -62,6 +75,7 @@ public partial class AgentServer
     /// <summary>Register an agent at a route. Throws if the route is already taken.</summary>
     public AgentServer Register(AgentBase agent, string? route = null)
     {
+        ArgumentNullException.ThrowIfNull(agent);
         route = NormalizeRoute(route ?? agent.Route);
 
         if (_agents.ContainsKey(route))
@@ -73,13 +87,14 @@ public partial class AgentServer
 
     public AgentServer Unregister(string route)
     {
+        ArgumentNullException.ThrowIfNull(route);
         route = NormalizeRoute(route);
         _agents.Remove(route);
         return this;
     }
 
     /// <summary>Return all registered routes (sorted).</summary>
-    public List<string> GetAgents()
+    public IReadOnlyList<string> GetAgents()
     {
         var routes = _agents.Keys.ToList();
         routes.Sort(StringComparer.Ordinal);
@@ -88,6 +103,7 @@ public partial class AgentServer
 
     public AgentBase? GetAgent(string route)
     {
+        ArgumentNullException.ThrowIfNull(route);
         route = NormalizeRoute(route);
         return _agents.TryGetValue(route, out var agent) ? agent : null;
     }
@@ -112,12 +128,16 @@ public partial class AgentServer
 
     public AgentServer RegisterSipUsername(string username, string route)
     {
+        ArgumentNullException.ThrowIfNull(route);
         route = NormalizeRoute(route);
         _sipUsernameMapping[username] = route;
         return this;
     }
 
     public bool IsSipRoutingEnabled => _sipRoutingEnabled;
+
+    [SuppressMessage("Design", "CA1024:Use properties where appropriate",
+        Justification = "get_* accessor matches the cross-port surface; returns a defensive copy")]
     public Dictionary<string, string> GetSipUsernameMapping() => new(_sipUsernameMapping);
 
     // ==================================================================
@@ -128,8 +148,11 @@ public partial class AgentServer
     /// Serve static files from <paramref name="directory"/> under <paramref name="urlPrefix"/>.
     /// Throws if the directory does not exist.
     /// </summary>
+    [SuppressMessage("Usage", "CA1054:URI-like parameters should not be strings",
+        Justification = "urlPrefix is a wire route prefix string, not a navigable URI")]
     public AgentServer ServeStatic(string directory, string urlPrefix)
     {
+        ArgumentNullException.ThrowIfNull(urlPrefix);
         var realDir = Path.GetFullPath(directory);
         if (!Directory.Exists(realDir))
             throw new InvalidOperationException($"Static directory '{directory}' does not exist");
@@ -147,6 +170,7 @@ public partial class AgentServer
     public (int Status, Dictionary<string, string> Headers, string Body) HandleRequest(
         string method, string path, Dictionary<string, string>? headers = null, string? body = null)
     {
+        ArgumentNullException.ThrowIfNull(path);
         headers ??= [];
         path = NormalizePath(path);
 
@@ -214,6 +238,8 @@ public partial class AgentServer
         return JsonResponse(200, new Dictionary<string, object> { ["agents"] = agentList });
     }
 
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types",
+        Justification = "Best-effort static-file path resolution and read; any failure falls through to skip the route or return 500.")]
     private (int, Dictionary<string, string>, string)? HandleStaticFile(string path)
     {
         // Sort by longest prefix first
@@ -255,7 +281,10 @@ public partial class AgentServer
 
             if (File.Exists(absPath))
             {
-                var ext = Path.GetExtension(absPath).TrimStart('.').ToLowerInvariant();
+                // MimeTypes uses OrdinalIgnoreCase, so the upper-cased
+                // extension still matches the lowercase keys; ToUpperInvariant
+                // is the analyzer-preferred normalization form.
+                var ext = Path.GetExtension(absPath).TrimStart('.').ToUpperInvariant();
                 var contentType = MimeTypes.TryGetValue(ext, out var mime) ? mime : "application/octet-stream";
 
                 try
@@ -263,7 +292,7 @@ public partial class AgentServer
                     var content = File.ReadAllText(absPath);
                     var responseHeaders = SecurityHeaders();
                     responseHeaders["Content-Type"] = contentType;
-                    responseHeaders["Content-Length"] = content.Length.ToString();
+                    responseHeaders["Content-Length"] = content.Length.ToString(CultureInfo.InvariantCulture);
                     return (200, responseHeaders, content);
                 }
                 catch

--- a/src/SignalWire/Serverless/Adapter.cs
+++ b/src/SignalWire/Serverless/Adapter.cs
@@ -55,6 +55,8 @@ public static class Adapter
         SWML.Service agent,
         Dictionary<string, object?> lambdaEvent)
     {
+        ArgumentNullException.ThrowIfNull(agent);
+        ArgumentNullException.ThrowIfNull(lambdaEvent);
         var method = GetStr(lambdaEvent, "httpMethod")?.ToUpperInvariant()
             ?? GetNestedStr(lambdaEvent, "requestContext", "http", "method")?.ToUpperInvariant()
             ?? "GET";
@@ -106,6 +108,8 @@ public static class Adapter
         SWML.Service agent,
         Dictionary<string, object?> request)
     {
+        ArgumentNullException.ThrowIfNull(agent);
+        ArgumentNullException.ThrowIfNull(request);
         var method = (GetStr(request, "method") ?? GetStr(request, "Method") ?? "GET").ToUpperInvariant();
         var url = GetStr(request, "url") ?? GetStr(request, "Url") ?? "/";
 
@@ -166,24 +170,24 @@ public static class Adapter
         switch (env)
         {
             case "lambda":
-            {
-                var input = Console.In.ReadToEnd();
-                var evt = string.IsNullOrEmpty(input) ? new Dictionary<string, object?>()
-                    : JsonSerializer.Deserialize<Dictionary<string, object?>>(input) ?? new();
-                var response = HandleLambda(agent, evt);
-                Console.Write(JsonSerializer.Serialize(response));
-                break;
-            }
+                {
+                    var input = Console.In.ReadToEnd();
+                    var evt = string.IsNullOrEmpty(input) ? new Dictionary<string, object?>()
+                        : JsonSerializer.Deserialize<Dictionary<string, object?>>(input) ?? new();
+                    var response = HandleLambda(agent, evt);
+                    Console.Write(JsonSerializer.Serialize(response));
+                    break;
+                }
 
             case "azure":
-            {
-                var input = Console.In.ReadToEnd();
-                var request = string.IsNullOrEmpty(input) ? new Dictionary<string, object?>()
-                    : JsonSerializer.Deserialize<Dictionary<string, object?>>(input) ?? new();
-                var response = HandleAzure(agent, request);
-                Console.Write(JsonSerializer.Serialize(response));
-                break;
-            }
+                {
+                    var input = Console.In.ReadToEnd();
+                    var request = string.IsNullOrEmpty(input) ? new Dictionary<string, object?>()
+                        : JsonSerializer.Deserialize<Dictionary<string, object?>>(input) ?? new();
+                    var response = HandleAzure(agent, request);
+                    Console.Write(JsonSerializer.Serialize(response));
+                    break;
+                }
 
             default:
                 agent.Run();

--- a/src/SignalWire/Skills/Builtin/ClaudeSkillsSkill.cs
+++ b/src/SignalWire/Skills/Builtin/ClaudeSkillsSkill.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
 using SignalWire.Agent;
@@ -111,6 +113,7 @@ public sealed class ClaudeSkillsSkill : SkillBase
         }
     }
 
+    [SuppressMessage("Design", "CA1031", Justification = "Best-effort section file read; any failure surfaces as an in-band error string to the caller.")]
     private Func<Dictionary<string, object>, Dictionary<string, object?>, FunctionResult> MakeHandler(ParsedSkill skill)
     {
         return (args, rawData) =>
@@ -144,18 +147,20 @@ public sealed class ClaudeSkillsSkill : SkillBase
         };
     }
 
+    [SuppressMessage("Design", "CA1031", Justification = "Best-effort SKILL.md read; an unreadable file is simply skipped (returns null).")]
+    [SuppressMessage("Globalization", "CA1308", Justification = "Frontmatter key normalization matched against lowercase literals; not a wire value.")]
     private static ParsedSkill? Parse(string skillFile, string fallbackName, bool ignoreInvocationControl)
     {
         string raw;
         try { raw = File.ReadAllText(skillFile, Encoding.UTF8); }
-        catch { return null; }
+        catch (Exception) { return null; }
 
         string? name = null, description = null, argumentHint = null;
         var disableModel = false;
         var userInvocable = true;
         string body;
 
-        if (raw.StartsWith("---"))
+        if (raw.StartsWith("---", StringComparison.Ordinal))
         {
             var rest = raw[3..];
             var endIdx = rest.IndexOf("\n---", StringComparison.Ordinal);
@@ -169,7 +174,7 @@ public sealed class ClaudeSkillsSkill : SkillBase
                 foreach (var line in fm.Split('\n'))
                 {
                     var trimmed = line.TrimEnd('\r');
-                    var colonIdx = trimmed.IndexOf(':');
+                    var colonIdx = trimmed.IndexOf(':', StringComparison.Ordinal);
                     if (colonIdx <= 0) continue;
                     var key = trimmed[..colonIdx].Trim();
                     var value = trimmed[(colonIdx + 1)..].Trim();
@@ -273,6 +278,7 @@ public sealed class ClaudeSkillsSkill : SkillBase
         return Regex.IsMatch(name, sb.ToString(), RegexOptions.IgnoreCase);
     }
 
+    [SuppressMessage("Globalization", "CA1308", Justification = "lowercase is the SWAIG tool-name wire convention.")]
     private static string Sanitize(string raw)
     {
         var lower = raw.ToLowerInvariant();
@@ -284,9 +290,9 @@ public sealed class ClaudeSkillsSkill : SkillBase
 
     private static string SubstituteVariables(string content, string skillDir, Dictionary<string, object?> rawData)
     {
-        content = content.Replace("${CLAUDE_SKILL_DIR}", skillDir);
+        content = content.Replace("${CLAUDE_SKILL_DIR}", skillDir, StringComparison.Ordinal);
         var sessionId = rawData.TryGetValue("call_id", out var cid) && cid is string cidStr ? cidStr : "";
-        content = content.Replace("${CLAUDE_SESSION_ID}", sessionId);
+        content = content.Replace("${CLAUDE_SESSION_ID}", sessionId, StringComparison.Ordinal);
         return content;
     }
 
@@ -300,15 +306,15 @@ public sealed class ClaudeSkillsSkill : SkillBase
 
         var result = IndexedArgRegex.Replace(body, m =>
         {
-            var idx = int.Parse(m.Groups[1].Value);
+            var idx = int.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture);
             return idx < positional.Length ? positional[idx] : "";
         });
         result = ShorthandArgRegex.Replace(result, m =>
         {
-            var idx = int.Parse(m.Groups[1].Value);
+            var idx = int.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture);
             return idx < positional.Length ? positional[idx] : "";
         });
-        result = result.Replace("$ARGUMENTS", arguments);
+        result = result.Replace("$ARGUMENTS", arguments, StringComparison.Ordinal);
         if (!hasBareArguments && arguments.Length > 0)
         {
             result += $"\n\nARGUMENTS: {arguments}";
@@ -356,6 +362,6 @@ public sealed class ClaudeSkillsSkill : SkillBase
     public override string GetInstanceKey()
     {
         var skillsPath = Params.TryGetValue("skills_path", out var sp) ? sp as string ?? "default" : "default";
-        return $"claude_skills_{skillsPath.GetHashCode():x}";
+        return $"claude_skills_{skillsPath.GetHashCode(StringComparison.Ordinal):x}";
     }
 }

--- a/src/SignalWire/Skills/Builtin/DatasphereServerlessSkill.cs
+++ b/src/SignalWire/Skills/Builtin/DatasphereServerlessSkill.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text;
 using SignalWire.Agent;
 using SignalWire.SWAIG;
@@ -29,8 +30,8 @@ public sealed class DatasphereServerlessSkill : SkillBase
         var projectId = Params.TryGetValue("project_id", out var pi) ? pi as string ?? "" : "";
         var token = Params.TryGetValue("token", out var tk) ? tk as string ?? "" : "";
         var documentId = Params.TryGetValue("document_id", out var di) ? di as string ?? "" : "";
-        var count = Params.TryGetValue("count", out var c) ? Math.Max(1, Math.Min(10, Convert.ToInt32(c))) : 1;
-        var distance = Params.TryGetValue("distance", out var d) ? Convert.ToDouble(d) : 3.0;
+        var count = Params.TryGetValue("count", out var c) ? Math.Max(1, Math.Min(10, Convert.ToInt32(c, CultureInfo.InvariantCulture))) : 1;
+        var distance = Params.TryGetValue("distance", out var d) ? Convert.ToDouble(d, CultureInfo.InvariantCulture) : 3.0;
 
         var authString = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{projectId}:{token}"));
         var noResultsMessage = Params.TryGetValue("no_results_message", out var nr)

--- a/src/SignalWire/Skills/Builtin/DatasphereSkill.cs
+++ b/src/SignalWire/Skills/Builtin/DatasphereSkill.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using SignalWire.Agent;
@@ -39,6 +41,7 @@ public sealed class DatasphereSkill : SkillBase
         return true;
     }
 
+    [SuppressMessage("Design", "CA1031", Justification = "Best-effort upstream search call; any failure is surfaced to the caller as an in-band error string.")]
     public override void RegisterTools(AgentBase agent)
     {
         var toolName = GetToolName("search_knowledge");
@@ -47,9 +50,9 @@ public sealed class DatasphereSkill : SkillBase
         var token = Params.TryGetValue("token", out var tk) ? tk as string ?? "" : "";
         var documentId = Params.TryGetValue("document_id", out var di) ? di as string ?? "" : "";
         var count = Params.TryGetValue("count", out var c)
-            ? Math.Max(1, Math.Min(10, Convert.ToInt32(c))) : 1;
+            ? Math.Max(1, Math.Min(10, Convert.ToInt32(c, CultureInfo.InvariantCulture))) : 1;
         var distance = Params.TryGetValue("distance", out var d)
-            ? Convert.ToDouble(d) : 3.0;
+            ? Convert.ToDouble(d, CultureInfo.InvariantCulture) : 3.0;
         var noResultsMessage = Params.TryGetValue("no_results_message", out var nm)
             ? nm as string ?? "I couldn't find any relevant information for '{query}' in the knowledge base."
             : "I couldn't find any relevant information for '{query}' in the knowledge base.";
@@ -63,7 +66,7 @@ public sealed class DatasphereSkill : SkillBase
                 {
                     ["type"] = "string",
                     ["description"] = "The search query to find relevant knowledge",
-                    ["required"] = true,
+                    // Not required — Python passes none (datasphere/skill.py:171).
                 },
             },
             (args, rawData) =>
@@ -98,7 +101,7 @@ public sealed class DatasphereSkill : SkillBase
                 }
                 if (Params.TryGetValue("max_synonyms", out var ms))
                 {
-                    body["max_synonyms"] = Convert.ToInt32(ms);
+                    body["max_synonyms"] = Convert.ToInt32(ms, CultureInfo.InvariantCulture);
                 }
 
                 int status;
@@ -169,7 +172,8 @@ public sealed class DatasphereSkill : SkillBase
 
     private static string FormatNoResults(string template, string query)
     {
-        return template.Contains("{query}") ? template.Replace("{query}", query) : template;
+        return template.Contains("{query}", StringComparison.Ordinal)
+            ? template.Replace("{query}", query, StringComparison.Ordinal) : template;
     }
 
     public override Dictionary<string, object> GetGlobalData() => new()

--- a/src/SignalWire/Skills/Builtin/GoogleMapsSkill.cs
+++ b/src/SignalWire/Skills/Builtin/GoogleMapsSkill.cs
@@ -35,8 +35,18 @@ public sealed class GoogleMapsSkill : SkillBase
                         ["type"] = "string",
                         ["description"] = "The address to look up",
                     },
+                    ["bias_lat"] = new Dictionary<string, object>
+                    {
+                        ["type"] = "number",
+                        ["description"] = "Latitude to bias results toward (optional)",
+                    },
+                    ["bias_lng"] = new Dictionary<string, object>
+                    {
+                        ["type"] = "number",
+                        ["description"] = "Longitude to bias results toward (optional)",
+                    },
                 },
-                ["required"] = new List<string> { "address" },
+                // No `required` — Python passes none (google_maps/skill.py:433).
             },
             ["data_map"] = new Dictionary<string, object>
             {
@@ -78,7 +88,7 @@ public sealed class GoogleMapsSkill : SkillBase
                     ["dest_lat"] = new Dictionary<string, object> { ["type"] = "number", ["description"] = "Latitude of the destination" },
                     ["dest_lng"] = new Dictionary<string, object> { ["type"] = "number", ["description"] = "Longitude of the destination" },
                 },
-                ["required"] = new List<string> { "origin_lat", "origin_lng", "dest_lat", "dest_lng" },
+                // No `required` — Python passes none (google_maps/skill.py:457).
             },
             ["data_map"] = new Dictionary<string, object>
             {

--- a/src/SignalWire/Skills/Builtin/HttpHelper.cs
+++ b/src/SignalWire/Skills/Builtin/HttpHelper.cs
@@ -56,7 +56,7 @@ internal static class HttpHelper
     {
         if (query is { Count: > 0 })
         {
-            var sep = url.Contains('?') ? "&" : "?";
+            var sep = url.Contains('?', StringComparison.Ordinal) ? "&" : "?";
             var sb = new StringBuilder(url);
             sb.Append(sep);
             var first = true;

--- a/src/SignalWire/Skills/Builtin/InfoGathererSkill.cs
+++ b/src/SignalWire/Skills/Builtin/InfoGathererSkill.cs
@@ -67,7 +67,7 @@ public sealed class InfoGathererSkill : SkillBase
                 {
                     ["type"] = "string",
                     ["description"] = "The answer to the current question",
-                    ["required"] = true,
+                    // Not required — Python's submit_answer passes none (info_gatherer/skill.py:170).
                 },
                 ["confirmed_by_user"] = new Dictionary<string, object>
                 {

--- a/src/SignalWire/Skills/Builtin/MathSkill.cs
+++ b/src/SignalWire/Skills/Builtin/MathSkill.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Text.RegularExpressions;
 using SignalWire.Agent;
 using SignalWire.SWAIG;
@@ -15,6 +17,7 @@ public sealed partial class MathSkill : SkillBase
 
     public override bool Setup(AgentBase agent, Dictionary<string, object> parameters) => true;
 
+    [SuppressMessage("Design", "CA1031", Justification = "Expression evaluation is best-effort; any failure is returned to the caller as an in-band error string.")]
     public override void RegisterTools(AgentBase agent)
     {
         DefineTool(
@@ -26,7 +29,7 @@ public sealed partial class MathSkill : SkillBase
                 {
                     ["type"] = "string",
                     ["description"] = "The mathematical expression to evaluate (e.g., \"2 + 3 * 4\")",
-                    ["required"] = true,
+                    // Not required — Python's math skill passes none (math/skill.py:33).
                 },
             },
             (args, rawData) =>
@@ -48,10 +51,10 @@ public sealed partial class MathSkill : SkillBase
 
                 try
                 {
-                    var sanitized = expression.Replace("^", "**");
+                    var sanitized = expression.Replace("^", "**", StringComparison.Ordinal);
                     var table = new System.Data.DataTable();
                     // DataTable.Compute supports basic arithmetic
-                    var simpleExpr = sanitized.Replace("**", "^");
+                    var simpleExpr = sanitized.Replace("**", "^", StringComparison.Ordinal);
                     var value = table.Compute(simpleExpr, "");
 
                     if (value is null || value == DBNull.Value)
@@ -60,7 +63,7 @@ public sealed partial class MathSkill : SkillBase
                     }
                     else
                     {
-                        var numValue = Convert.ToDouble(value);
+                        var numValue = Convert.ToDouble(value, CultureInfo.InvariantCulture);
                         if (double.IsInfinity(numValue))
                         {
                             result.SetResponse("Error: Division by zero or overflow in expression.");

--- a/src/SignalWire/Skills/Builtin/McpGatewaySkill.cs
+++ b/src/SignalWire/Skills/Builtin/McpGatewaySkill.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Text.Json;
 using SignalWire.Agent;
 using SignalWire.SWAIG;
@@ -40,9 +42,9 @@ public sealed class McpGatewaySkill : SkillBase
         var authUser = Params.TryGetValue("auth_user", out var au) ? au as string ?? "" : "";
         var authPassword = Params.TryGetValue("auth_password", out var ap) ? ap as string ?? "" : "";
         var toolPrefix = Params.TryGetValue("tool_prefix", out var tp) ? tp as string ?? "mcp_" : "mcp_";
-        var sessionTimeout = Params.TryGetValue("session_timeout", out var st) ? Convert.ToInt32(st) : 300;
-        var requestTimeout = Params.TryGetValue("request_timeout", out var rt) ? Convert.ToInt32(rt) : 30;
-        var retryAttempts = Params.TryGetValue("retry_attempts", out var ra) ? Math.Max(1, Convert.ToInt32(ra)) : 3;
+        var sessionTimeout = Params.TryGetValue("session_timeout", out var st) ? Convert.ToInt32(st, CultureInfo.InvariantCulture) : 300;
+        var requestTimeout = Params.TryGetValue("request_timeout", out var rt) ? Convert.ToInt32(rt, CultureInfo.InvariantCulture) : 30;
+        var retryAttempts = Params.TryGetValue("retry_attempts", out var ra) ? Math.Max(1, Convert.ToInt32(ra, CultureInfo.InvariantCulture)) : 3;
 
         if (services.Count == 0)
         {
@@ -131,6 +133,7 @@ public sealed class McpGatewaySkill : SkillBase
                          sessionTimeout, requestTimeout, retryAttempts, "", ""));
     }
 
+    [SuppressMessage("Design", "CA1031", Justification = "Per-attempt failures are caught to drive retry/fallback; the last error is surfaced to the caller as an in-band string.")]
     private static Func<Dictionary<string, object>, Dictionary<string, object?>, FunctionResult> BuildHandler(
         string gatewayUrl, string authToken, string authUser, string authPassword,
         int sessionTimeout, int requestTimeout, int retryAttempts,

--- a/src/SignalWire/Skills/Builtin/NativeVectorSearchSkill.cs
+++ b/src/SignalWire/Skills/Builtin/NativeVectorSearchSkill.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using SignalWire.Agent;
@@ -28,16 +30,17 @@ public sealed class NativeVectorSearchSkill : SkillBase
 
     public override bool Setup(AgentBase agent, Dictionary<string, object> parameters) => true;
 
+    [SuppressMessage("Design", "CA1031", Justification = "Best-effort remote search call; any failure is surfaced to the caller as an in-band error string.")]
     public override void RegisterTools(AgentBase agent)
     {
         var toolName = GetToolName("search_knowledge");
         var description = Params.TryGetValue("description", out var d)
             ? d as string ?? "Search the local knowledge base for information"
             : "Search the local knowledge base for information";
-        var defaultCount = Params.TryGetValue("count", out var c) ? Math.Max(1, Convert.ToInt32(c)) : 5;
+        var defaultCount = Params.TryGetValue("count", out var c) ? Math.Max(1, Convert.ToInt32(c, CultureInfo.InvariantCulture)) : 5;
         var indexName = Params.TryGetValue("index_name", out var idx) ? idx as string ?? "default" : "default";
         var similarityThreshold = Params.TryGetValue("similarity_threshold", out var st)
-            ? Convert.ToDouble(st) : 0.0;
+            ? Convert.ToDouble(st, CultureInfo.InvariantCulture) : 0.0;
         var tags = Params.TryGetValue("tags", out var tg) && tg is List<string> tagList ? tagList : [];
         var noResultsMessage = Params.TryGetValue("no_results_message", out var nm)
             ? nm as string ?? "No information found for '{query}'" : "No information found for '{query}'";
@@ -70,7 +73,7 @@ public sealed class NativeVectorSearchSkill : SkillBase
                 {
                     return new FunctionResult("Please provide a search query.");
                 }
-                var count = args.TryGetValue("count", out var cn) ? Convert.ToInt32(cn) : defaultCount;
+                var count = args.TryGetValue("count", out var cn) ? Convert.ToInt32(cn, CultureInfo.InvariantCulture) : defaultCount;
                 if (remoteUrl.Length == 0)
                 {
                     // Local mode requires sentence-transformers / FAISS; not
@@ -93,7 +96,7 @@ public sealed class NativeVectorSearchSkill : SkillBase
                     {
                         basicAuth = (Uri.UnescapeDataString(parts[0]), Uri.UnescapeDataString(parts[1]));
                     }
-                    requestUrl = u.GetLeftPart(UriPartial.Authority).Replace(u.UserInfo + "@", "") + u.PathAndQuery;
+                    requestUrl = u.GetLeftPart(UriPartial.Authority).Replace(u.UserInfo + "@", "", StringComparison.Ordinal) + u.PathAndQuery;
                 }
 
                 // The Python skill POSTs to the search server's `/search`
@@ -138,8 +141,8 @@ public sealed class NativeVectorSearchSkill : SkillBase
                     || results.ValueKind != JsonValueKind.Array
                     || results.GetArrayLength() == 0)
                 {
-                    var msg = noResultsMessage.Contains("{query}")
-                        ? noResultsMessage.Replace("{query}", query) : noResultsMessage;
+                    var msg = noResultsMessage.Contains("{query}", StringComparison.Ordinal)
+                        ? noResultsMessage.Replace("{query}", query, StringComparison.Ordinal) : noResultsMessage;
                     if (responsePrefix.Length > 0) msg = responsePrefix + " " + msg;
                     if (responsePostfix.Length > 0) msg = msg + " " + responsePostfix;
                     return new FunctionResult(msg);

--- a/src/SignalWire/Skills/Builtin/SpiderSkill.cs
+++ b/src/SignalWire/Skills/Builtin/SpiderSkill.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
 using SignalWire.Agent;
@@ -36,14 +38,15 @@ public sealed class SpiderSkill : SkillBase
 
     public override bool Setup(AgentBase agent, Dictionary<string, object> parameters) => true;
 
+    [SuppressMessage("Design", "CA1031", Justification = "Per-page fetch/scrape failures are best-effort; each is surfaced in-band or skipped so the crawl can continue.")]
     public override void RegisterTools(AgentBase agent)
     {
         var prefix = Params.TryGetValue("tool_name", out var p) && p is string ps && ps.Length > 0 ? ps + "_" : "";
-        var maxLength = Params.TryGetValue("max_text_length", out var ml) ? Convert.ToInt32(ml) : 5000;
-        var timeout = Params.TryGetValue("timeout", out var to) ? Math.Max(2, Convert.ToInt32(to)) : 15;
+        var maxLength = Params.TryGetValue("max_text_length", out var ml) ? Convert.ToInt32(ml, CultureInfo.InvariantCulture) : 5000;
+        var timeout = Params.TryGetValue("timeout", out var to) ? Math.Max(2, Convert.ToInt32(to, CultureInfo.InvariantCulture)) : 15;
         var userAgent = Params.TryGetValue("user_agent", out var ua) ? ua as string ?? "SignalWire-Spider/1.0" : "SignalWire-Spider/1.0";
-        var maxPages = Params.TryGetValue("max_pages", out var mp) ? Math.Max(1, Convert.ToInt32(mp)) : 1;
-        var maxDepth = Params.TryGetValue("max_depth", out var md) ? Math.Max(0, Convert.ToInt32(md)) : 0;
+        var maxPages = Params.TryGetValue("max_pages", out var mp) ? Math.Max(1, Convert.ToInt32(mp, CultureInfo.InvariantCulture)) : 1;
+        var maxDepth = Params.TryGetValue("max_depth", out var md) ? Math.Max(0, Convert.ToInt32(md, CultureInfo.InvariantCulture)) : 0;
 
         DefineTool(
             prefix + "scrape_url",
@@ -142,7 +145,7 @@ public sealed class SpiderSkill : SkillBase
                             }
                         }
                     }
-                    catch
+                    catch (Exception)
                     {
                         // ignore individual page failures and continue
                     }
@@ -278,7 +281,7 @@ public sealed class SpiderSkill : SkillBase
             if (m.Success) result.Add(StripHtml(m.Groups[1].Value));
             return result;
         }
-        var dot = selector.IndexOf('.');
+        var dot = selector.IndexOf('.', StringComparison.Ordinal);
         var tag = dot < 0 ? selector : selector[..dot];
         var matches = Regex.Matches(html, $@"<{Regex.Escape(tag)}\b[^>]*>([\s\S]*?)</{Regex.Escape(tag)}>",
             RegexOptions.IgnoreCase);

--- a/src/SignalWire/Skills/Builtin/SwmlTransferSkill.cs
+++ b/src/SignalWire/Skills/Builtin/SwmlTransferSkill.cs
@@ -25,15 +25,16 @@ public sealed class SwmlTransferSkill : SkillBase
         var paramDescription = Params.TryGetValue("parameter_description", out var pd) ? pd as string ?? "The type of transfer to perform" : "The type of transfer to perform";
         var defaultMessage = Params.TryGetValue("default_message", out var dm) ? dm as string ?? "Transferring your call, please hold." : "Transferring your call, please hold.";
 
-        var transferKeys = transfers.Keys.ToList();
-
+        // The transfer key is a plain required string with NO enum — Python's
+        // swml_transfer does not put the transfer keys in the param schema
+        // (swml_transfer/skill.py:186); the keys drive DataMap pattern-matching
+        // expressions, not the param's enum.
         var properties = new Dictionary<string, object>
         {
             [paramName] = new Dictionary<string, object>
             {
                 ["type"] = "string",
                 ["description"] = paramDescription,
-                ["enum"] = transferKeys,
             },
         };
         var required = new List<string> { paramName };
@@ -62,7 +63,7 @@ public sealed class SwmlTransferSkill : SkillBase
             if (url.Length > 0)
             {
                 var actionList = (List<Dictionary<string, object>>)((Dictionary<string, object>)expression["output"])["action"];
-                if (url.StartsWith("http://") || url.StartsWith("https://"))
+                if (url.StartsWith("http://", StringComparison.Ordinal) || url.StartsWith("https://", StringComparison.Ordinal))
                 {
                     actionList.Add(new Dictionary<string, object> { ["transfer_uri"] = url });
                 }

--- a/src/SignalWire/Skills/Builtin/WebSearchSkill.cs
+++ b/src/SignalWire/Skills/Builtin/WebSearchSkill.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
@@ -63,15 +65,16 @@ public sealed class WebSearchSkill : SkillBase
             && parameters.TryGetValue("search_engine_id", out var se) && se is string sid && sid.Length > 0;
     }
 
+    [SuppressMessage("Design", "CA1031", Justification = "Best-effort CSE search call; any failure is surfaced to the caller as an in-band error string.")]
     public override void RegisterTools(AgentBase agent)
     {
         var toolName = GetToolName("web_search");
         var apiKey = Params.TryGetValue("api_key", out var k) ? k as string ?? "" : "";
         var searchEngineId = Params.TryGetValue("search_engine_id", out var se) ? se as string ?? "" : "";
         var numResults = Params.TryGetValue("num_results", out var nr)
-            ? Math.Max(1, Math.Min(10, Convert.ToInt32(nr)))
+            ? Math.Max(1, Math.Min(10, Convert.ToInt32(nr, CultureInfo.InvariantCulture)))
             : 3;
-        var timeout = Params.TryGetValue("timeout", out var to) ? Math.Max(2, Convert.ToInt32(to)) : 15;
+        var timeout = Params.TryGetValue("timeout", out var to) ? Math.Max(2, Convert.ToInt32(to, CultureInfo.InvariantCulture)) : 15;
         var noResultsMessage = Params.TryGetValue("no_results_message", out var nm)
             ? nm as string ?? "No results found for the given query."
             : "No results found for the given query.";
@@ -105,7 +108,7 @@ public sealed class WebSearchSkill : SkillBase
                 {
                     ["type"] = "string",
                     ["description"] = "The search query",
-                    ["required"] = true,
+                    // Not required — Python passes none (web_search/skill.py:707).
                 },
             },
             (args, rawData) =>
@@ -122,7 +125,7 @@ public sealed class WebSearchSkill : SkillBase
                     ["key"] = apiKey,
                     ["cx"] = searchEngineId,
                     ["q"] = query,
-                    ["num"] = numResults.ToString(),
+                    ["num"] = numResults.ToString(CultureInfo.InvariantCulture),
                 };
 
                 int status;
@@ -229,6 +232,7 @@ public sealed class WebSearchSkill : SkillBase
     /// breaking once the deadline fires. The overall_deadline is enforced in
     /// BOTH modes. Mirrors Python's parallel/sequential scrape loop.
     /// </summary>
+    [SuppressMessage("Design", "CA1031", Justification = "Deadline-bounded best-effort scrape batch; any per-batch failure is swallowed so completed work can still be harvested.")]
     private static List<ScrapedResult> ScrapeCandidates(
         string query,
         List<SearchResult> candidates,
@@ -292,6 +296,7 @@ public sealed class WebSearchSkill : SkillBase
     /// cancelled/failed, or the content is below the quality threshold. Mirrors
     /// Python's <c>_scrape_one</c> closure.
     /// </summary>
+    [SuppressMessage("Design", "CA1031", Justification = "Per-page scrape is best-effort and bounded by per_page_timeout/overall_deadline; any failure abandons just that page (returns null).")]
     private static async Task<ScrapedResult?> ScrapeOneAsync(
         string query,
         SearchResult candidate,
@@ -344,6 +349,7 @@ public sealed class WebSearchSkill : SkillBase
     }
 
     /// <summary>Default scrape handler: a plain <see cref="SocketsHttpHandler"/>.</summary>
+    [SuppressMessage("Performance", "CA1859", Justification = "Return type must stay HttpMessageHandler to match the Func<HttpMessageHandler> ScrapeHandlerFactory delegate used via the ?? fallback.")]
     private static HttpMessageHandler DefaultScrapeHandler() => new SocketsHttpHandler();
 
     // A scraped page must clear this minimal quality bar to be kept. Python's
@@ -378,12 +384,12 @@ public sealed class WebSearchSkill : SkillBase
         if (text.Length < 50) return 0.0;
         var lengthScore = Math.Min(1.0, text.Length / 1000.0);
         var relevance = 0.0;
-        var lowered = text.ToLowerInvariant();
-        var words = query.ToLowerInvariant().Split(
+        var uppered = text.ToUpperInvariant();
+        var words = query.ToUpperInvariant().Split(
             (char[]?)null, StringSplitOptions.RemoveEmptyEntries);
         if (words.Length > 0)
         {
-            var found = words.Count(w => lowered.Contains(w));
+            var found = words.Count(w => uppered.Contains(w, StringComparison.Ordinal));
             relevance = (double)found / words.Length;
         }
         return (lengthScore * 0.5) + (relevance * 0.5);
@@ -460,29 +466,32 @@ public sealed class WebSearchSkill : SkillBase
 
     private static string FormatNoResults(string template, string query)
     {
-        return template.Contains("{query}") ? template.Replace("{query}", query) : template;
+        return template.Contains("{query}", StringComparison.Ordinal)
+            ? template.Replace("{query}", query, StringComparison.Ordinal) : template;
     }
 
     // ------------------------------------------------------------------
     //  Param helpers
     // ------------------------------------------------------------------
 
+    [SuppressMessage("Design", "CA1031", Justification = "Lenient param coercion; any conversion failure falls back to the supplied default.")]
     private double GetParamDouble(string name, double fallback)
     {
         if (Params.TryGetValue(name, out var v) && v is not null)
         {
-            try { return Convert.ToDouble(v); }
-            catch { return fallback; }
+            try { return Convert.ToDouble(v, CultureInfo.InvariantCulture); }
+            catch (Exception) { return fallback; }
         }
         return fallback;
     }
 
+    [SuppressMessage("Design", "CA1031", Justification = "Lenient param coercion; any conversion failure falls back to the supplied default.")]
     private bool GetParamBool(string name, bool fallback)
     {
         if (Params.TryGetValue(name, out var v) && v is not null)
         {
-            try { return Convert.ToBoolean(v); }
-            catch { return fallback; }
+            try { return Convert.ToBoolean(v, CultureInfo.InvariantCulture); }
+            catch (Exception) { return fallback; }
         }
         return fallback;
     }

--- a/src/SignalWire/Skills/Builtin/WikipediaSearchSkill.cs
+++ b/src/SignalWire/Skills/Builtin/WikipediaSearchSkill.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using SignalWire.Agent;
@@ -29,10 +31,11 @@ public sealed class WikipediaSearchSkill : SkillBase
 
     public override bool Setup(AgentBase agent, Dictionary<string, object> parameters) => true;
 
+    [SuppressMessage("Design", "CA1031", Justification = "Best-effort Wikipedia API call; any failure is surfaced to the caller as an in-band error string.")]
     public override void RegisterTools(AgentBase agent)
     {
         var numResults = Params.TryGetValue("num_results", out var nr)
-            ? Math.Max(1, Math.Min(5, Convert.ToInt32(nr)))
+            ? Math.Max(1, Math.Min(5, Convert.ToInt32(nr, CultureInfo.InvariantCulture)))
             : 1;
         var noResultsMessage = Params.TryGetValue("no_results_message", out var nm)
             ? nm as string ?? "I couldn't find any Wikipedia articles for '{query}'."
@@ -47,7 +50,7 @@ public sealed class WikipediaSearchSkill : SkillBase
                 {
                     ["type"] = "string",
                     ["description"] = "The topic to search for on Wikipedia",
-                    ["required"] = true,
+                    // Not required — Python passes none (wikipedia_search/skill.py:87).
                 },
             },
             (args, rawData) =>
@@ -69,7 +72,7 @@ public sealed class WikipediaSearchSkill : SkillBase
                         ["list"] = "search",
                         ["format"] = "json",
                         ["srsearch"] = query,
-                        ["srlimit"] = numResults.ToString(),
+                        ["srlimit"] = numResults.ToString(CultureInfo.InvariantCulture),
                     };
                     var (sStatus, _, sParsed) = HttpHelper.GetAsync(baseUrl, searchParams)
                         .ConfigureAwait(false).GetAwaiter().GetResult();
@@ -156,7 +159,8 @@ public sealed class WikipediaSearchSkill : SkillBase
 
     private static string FormatNoResults(string template, string query)
     {
-        return template.Contains("{query}") ? template.Replace("{query}", query) : template;
+        return template.Contains("{query}", StringComparison.Ordinal)
+            ? template.Replace("{query}", query, StringComparison.Ordinal) : template;
     }
 
     public override List<Dictionary<string, object>> GetPromptSections()

--- a/src/SignalWire/Skills/SkillBase.cs
+++ b/src/SignalWire/Skills/SkillBase.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using SignalWire.Agent;
 using SignalWire.SWAIG;
 
@@ -28,6 +29,8 @@ public abstract class SkillBase
     // ------------------------------------------------------------------
 
     public virtual string Version => "1.0.0";
+
+    [SuppressMessage("Design", "CA1002", Justification = "Virtual member overridden by built-in skill subclasses; changing the type would break the override surface across un-owned files.")]
     public virtual List<string> RequiredEnvVars => [];
     public virtual bool SupportsMultipleInstances => false;
 
@@ -41,10 +44,12 @@ public abstract class SkillBase
         return key;
     }
 
+    [SuppressMessage("Design", "CA1002", Justification = "Virtual member overridden by built-in skill subclasses; changing the type would break the override surface across un-owned files.")]
     public virtual List<string> GetHints() => [];
 
     public virtual Dictionary<string, object> GetGlobalData() => [];
 
+    [SuppressMessage("Design", "CA1002", Justification = "Virtual member overridden by built-in skill subclasses; changing the type would break the override surface across un-owned files.")]
     public virtual List<Dictionary<string, object>> GetPromptSections()
     {
         if (_params.TryGetValue("skip_prompt", out var sp) && sp is true)
@@ -104,7 +109,7 @@ public abstract class SkillBase
     //  Env var validation
     // ------------------------------------------------------------------
 
-    public List<string> ValidateEnvVars()
+    public IReadOnlyList<string> ValidateEnvVars()
     {
         var missing = new List<string>();
         foreach (var varName in RequiredEnvVars)
@@ -131,6 +136,7 @@ public abstract class SkillBase
         Dictionary<string, object> parameters,
         Func<Dictionary<string, object>, Dictionary<string, object?>, FunctionResult> handler)
     {
+        ArgumentNullException.ThrowIfNull(parameters);
         if (_swaigFields.Count > 0)
         {
             foreach (var field in _swaigFields)
@@ -164,6 +170,7 @@ public abstract class SkillBase
 
     public void Wire(AgentBase agent, Dictionary<string, object> parameters)
     {
+        ArgumentNullException.ThrowIfNull(parameters);
         _agent = agent;
         _params = parameters;
 

--- a/src/SignalWire/Skills/SkillManager.cs
+++ b/src/SignalWire/Skills/SkillManager.cs
@@ -116,10 +116,10 @@ public sealed class SkillManager
         return true;
     }
 
-    public List<string> ListSkills()
+    public IReadOnlyList<string> ListSkills()
     {
         var keys = _loadedSkills.Keys.ToList();
-        keys.Sort();
+        keys.Sort(StringComparer.Ordinal);
         return keys;
     }
 

--- a/src/SignalWire/Skills/SkillRegistry.cs
+++ b/src/SignalWire/Skills/SkillRegistry.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using SignalWire.Logging;
 using SignalWire.Skills.Builtin;
 
@@ -60,6 +61,7 @@ public sealed class SkillRegistry
 
     private SkillRegistry() { }
 
+    [SuppressMessage("Reliability", "CA1508", Justification = "Double-checked locking: the analyzer cannot model the concurrent re-assignment of _instance inside the lock, so it wrongly reports the inner null-check as dead.")]
     public static SkillRegistry Instance
     {
         get
@@ -98,7 +100,7 @@ public sealed class SkillRegistry
     /// this returns the discoverable inventory (mirrors <see cref="ListSkills"/>).
     /// (Python parity: ``SkillRegistry.discover_skills`` now returns
     /// ``list_skills()`` — it was a no-op until the reference stub was fixed.)</summary>
-    public List<string> DiscoverSkills()
+    public IReadOnlyList<string> DiscoverSkills()
     {
         return ListSkills();
     }
@@ -159,16 +161,16 @@ public sealed class SkillRegistry
     }
 
     /// <summary>Return all known skill names (builtins + custom), sorted.</summary>
-    public List<string> ListSkills()
+    public IReadOnlyList<string> ListSkills()
     {
         lock (Lock)
         {
             // Ensure all builtins are registered
             foreach (var name in BuiltinSkillNames)
             {
-                if (!_registeredSkills.ContainsKey(name) && BuiltinFactories.ContainsKey(name))
+                if (!_registeredSkills.ContainsKey(name) && BuiltinFactories.TryGetValue(name, out var factory))
                 {
-                    _registeredSkills[name] = BuiltinFactories[name];
+                    _registeredSkills[name] = factory;
                 }
             }
 

--- a/src/SignalWire/Utils/UrlValidator.cs
+++ b/src/SignalWire/Utils/UrlValidator.cs
@@ -7,6 +7,7 @@
 // passed true or ``SWML_ALLOW_PRIVATE_URLS`` is set.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Sockets;
 
@@ -14,10 +15,18 @@ namespace SignalWire.Utils;
 
 public static class UrlValidator
 {
+    private static readonly string[] TruthyEnvValues = { "1", "true", "yes" };
+
+    private static bool IsTruthyEnv(string? value) =>
+        value is not null && Array.Exists(
+            TruthyEnvValues,
+            v => string.Equals(v, value, StringComparison.OrdinalIgnoreCase));
+
     /// <summary>Validate that a URL is safe to fetch (not pointing to
     /// private/internal resources). Returns true when safe, false when
     /// rejected. (Python parity:
     /// ``signalwire.utils.url_validator.validate_url(url, allow_private)``.)</summary>
+    [SuppressMessage("Usage", "CA1054", Justification = "URL is a wire string sent verbatim to the SignalWire API and validated as text; converting churns call sites.")]
     public static bool ValidateUrl(string url, bool allowPrivate = false)
     {
         if (string.IsNullOrEmpty(url)) return false;
@@ -41,8 +50,7 @@ public static class UrlValidator
         }
 
         var envBypass = Environment.GetEnvironmentVariable("SWML_ALLOW_PRIVATE_URLS");
-        if (allowPrivate
-            || (envBypass is not null && envBypass.ToLowerInvariant() is "1" or "true" or "yes"))
+        if (allowPrivate || IsTruthyEnv(envBypass))
         {
             return true;
         }
@@ -77,6 +85,7 @@ public static class UrlValidator
     /// <summary>Test-friendly overload that accepts already-resolved IPs
     /// instead of doing a live DNS lookup. Cross-language audit / unit
     /// tests use this to exercise the blocked-range logic deterministically.</summary>
+    [SuppressMessage("Usage", "CA1054", Justification = "URL is a wire string sent verbatim to the SignalWire API and validated as text; converting churns call sites.")]
     public static bool ValidateUrlWithResolvedAddresses(
         string url,
         IPAddress[] resolvedAddresses,
@@ -88,8 +97,7 @@ public static class UrlValidator
         if (string.IsNullOrEmpty(uri.Host)) return false;
 
         var envBypass = Environment.GetEnvironmentVariable("SWML_ALLOW_PRIVATE_URLS");
-        if (allowPrivate
-            || (envBypass is not null && envBypass.ToLowerInvariant() is "1" or "true" or "yes"))
+        if (allowPrivate || IsTruthyEnv(envBypass))
         {
             return true;
         }

--- a/tests/ContextsTests.cs
+++ b/tests/ContextsTests.cs
@@ -56,7 +56,9 @@ public class ContextsTests
     {
         var q = new GatherQuestion(new Dictionary<string, object>
         {
-            ["key"] = "x", ["question"] = "Q?", ["type"] = "string",
+            ["key"] = "x",
+            ["question"] = "Q?",
+            ["type"] = "string",
         });
         Assert.False(q.ToDict().ContainsKey("type"));
     }
@@ -66,7 +68,9 @@ public class ContextsTests
     {
         var q = new GatherQuestion(new Dictionary<string, object>
         {
-            ["key"] = "x", ["question"] = "Q?", ["type"] = "boolean",
+            ["key"] = "x",
+            ["question"] = "Q?",
+            ["type"] = "boolean",
         });
         Assert.Equal("boolean", q.ToDict()["type"]);
     }
@@ -308,7 +312,9 @@ public class ContextsTests
         step.SetText("text");
         step.SetGatherInfo(new Dictionary<string, object>
         {
-            ["output_key"] = "info", ["completion_action"] = "next_step", ["prompt"] = "Answer these questions",
+            ["output_key"] = "info",
+            ["completion_action"] = "next_step",
+            ["prompt"] = "Answer these questions",
         });
         step.AddGatherQuestion(new Dictionary<string, object> { ["key"] = "name", ["question"] = "Your name?" });
 

--- a/tests/FunctionResultTests.cs
+++ b/tests/FunctionResultTests.cs
@@ -918,9 +918,13 @@ public class FunctionResultTests
         var enumFr = new FunctionResult();
         enumFr.JoinConference("team-meeting", new JoinConferenceOptions
         {
-            Muted = true, Beep = ConferenceBeep.OnEnter, MaxParticipants = 50,
-            Record = ConferenceRecord.RecordFromStart, Trim = ConferenceTrim.DoNotTrim,
-            StatusCallbackMethod = CallbackMethod.Get, WaitUrl = "https://example.com/hold-music",
+            Muted = true,
+            Beep = ConferenceBeep.OnEnter,
+            MaxParticipants = 50,
+            Record = ConferenceRecord.RecordFromStart,
+            Trim = ConferenceTrim.DoNotTrim,
+            StatusCallbackMethod = CallbackMethod.Get,
+            WaitUrl = "https://example.com/hold-music",
         });
         var enumJc = MainVerb(GetAction(enumFr, 0), "join_conference");
 

--- a/tests/FunctionResultTests.cs
+++ b/tests/FunctionResultTests.cs
@@ -312,7 +312,7 @@ public class FunctionResultTests
         // {"unset_global_data": ["user_id", "session", "token"]} — bare list, no {keys} wrapper.
         var fr = new FunctionResult();
         fr.RemoveGlobalData(["user_id", "session", "token"]);
-        var keys = (List<string>)GetAction(fr, 0)["unset_global_data"];
+        var keys = (IReadOnlyList<string>)GetAction(fr, 0)["unset_global_data"];
         Assert.Equal(new List<string> { "user_id", "session", "token" }, keys);
     }
 
@@ -345,7 +345,7 @@ public class FunctionResultTests
         // {"unset_meta_data": ["key1", "key2"]} — bare list.
         var fr = new FunctionResult();
         fr.RemoveMetadata(["key1", "key2"]);
-        var keys = (List<string>)GetAction(fr, 0)["unset_meta_data"];
+        var keys = (IReadOnlyList<string>)GetAction(fr, 0)["unset_meta_data"];
         Assert.Equal(new List<string> { "key1", "key2" }, keys);
     }
 

--- a/tests/ParameterSchemaTests.cs
+++ b/tests/ParameterSchemaTests.cs
@@ -335,13 +335,16 @@ public class ParameterSchemaTests : IDisposable
         Assert.Equal("object", argument["type"]);
         var properties = (Dictionary<string, object>)argument["properties"];
 
-        // Builder-produced parameters are present, byte-identical to what we built.
-        Assert.Equal(parameters, properties);
-
+        // DefineTool lifts per-property `required: true` into the top-level
+        // JSON-Schema `required` array (standard form), so the rendered
+        // properties no longer carry the per-property flag.
         var serviceProp = (Dictionary<string, object>)properties["service"];
         Assert.Equal("string", serviceProp["type"]);
         Assert.Equal("The service to book", serviceProp["description"]);
-        Assert.True((bool)serviceProp["required"]);
+        Assert.False(serviceProp.ContainsKey("required"));
+
+        // The required names are lifted to argument.required (in declared order).
+        Assert.Equal(new List<string> { "service", "date" }, (List<string>)argument["required"]);
 
         var formatProp = (Dictionary<string, object>)properties["format"];
         Assert.Equal(new List<string> { "wav", "mp3", "mp4" }, (List<string>)formatProp["enum"]);

--- a/tests/RelayMock/ConnectMockTest.cs
+++ b/tests/RelayMock/ConnectMockTest.cs
@@ -273,7 +273,7 @@ public class ConnectMockTest : IClassFixture<RelayMockServerFixture>
             ["params"] = new Dictionary<string, object?>
             {
                 ["version"] = new Dictionary<string, int>
-                    { ["major"] = 2, ["minor"] = 0, ["revision"] = 0 },
+                { ["major"] = 2, ["minor"] = 0, ["revision"] = 0 },
                 ["agent"] = "signalwire-dotnet-mock-tests/1.0",
                 ["authentication"] = new Dictionary<string, object?>
                 {
@@ -331,7 +331,7 @@ public class ConnectMockTest : IClassFixture<RelayMockServerFixture>
             ["params"] = new Dictionary<string, object?>
             {
                 ["version"] = new Dictionary<string, int>
-                    { ["major"] = 2, ["minor"] = 0, ["revision"] = 0 },
+                { ["major"] = 2, ["minor"] = 0, ["revision"] = 0 },
                 ["agent"] = "signalwire-dotnet-mock-tests/1.0",
                 ["authentication"] = new Dictionary<string, object?>
                 {

--- a/tests/SWMLDocumentTests.cs
+++ b/tests/SWMLDocumentTests.cs
@@ -218,15 +218,20 @@ public class SWMLDocumentTests : IDisposable
     }
 
     [Fact]
-    public void GetVerbs_ReturnsCopy_MutationDoesNotAffectOriginal()
+    public void GetVerbs_ReturnsSnapshot_NotAffectedByLaterAdds()
     {
         var doc = new Document();
         doc.AddVerb("answer", new Dictionary<string, object>());
 
+        // GetVerbs returns an IReadOnlyList snapshot — callers cannot mutate it
+        // (the type enforces what the old test asserted by trying to .Add), and
+        // it does not observe verbs added to the document afterward.
         var verbs = doc.GetVerbs("main");
-        verbs.Add(new Dictionary<string, object> { ["extra"] = "should not affect original" });
+        Assert.Single(verbs);
 
-        Assert.Single(doc.GetVerbs("main"));
+        doc.AddVerb("hangup", new Dictionary<string, object>());
+        Assert.Single(verbs); // the earlier snapshot is unchanged
+        Assert.Equal(2, doc.GetVerbs("main").Count); // a fresh call sees both
     }
 
     [Fact]

--- a/tools/EmitSkills/EmitSkills.csproj
+++ b/tools/EmitSkills/EmitSkills.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>SignalWire.Tools.EmitSkills</RootNamespace>
+    <AssemblyName>EmitSkills</AssemblyName>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\SignalWire\SignalWire.csproj" />
+  </ItemGroup>
+</Project>

--- a/tools/EmitSkills/Program.cs
+++ b/tools/EmitSkills/Program.cs
@@ -1,0 +1,162 @@
+// EmitSkills — the .NET port's SKILL-DUMP program for the cross-port
+// SKILL-CONTRACT differ (porting-sdk/scripts/diff_skill_contracts.py).
+//
+// The sibling of tools/EmitCorpus, for built-in SKILLS rather than
+// FunctionResult. For each covered skill it looks up the factory in the
+// SkillRegistry, instantiates it with the canonical config from the shared
+// corpus (porting-sdk/scripts/skill_contract_corpus.py — the single source of
+// truth), runs Wire() + Setup() + RegisterTools() onto a throwaway AgentBase,
+// reads the registered tools back (each tool's "argument" is the wrapped
+// {type:object, properties[, required]}), and prints ONE JSON object mapping
+//
+//     skill-id -> [ { "name": ..., "parameters": {...} }, ... ]
+//
+// to stdout. The differ parses it and structurally compares each skill's tool
+// contract against the Python reference. The differ normalises both sides
+// (flat vs wrapped params, per-param vs tool-level required, enum order); this
+// program emits each tool's "function" name and its "argument" verbatim.
+// DESCRIPTIONS are not part of the compared contract.
+//
+// CONTRACT (mirrors the per-port dump contract in the differ's --help):
+//   - The id set MUST equal corpus_ids() (the differ rejects a mismatch).
+//   - Only stdout carries the JSON object; logs/build chatter go to stderr
+//     (scripts/emit-skills.sh routes MSBuild to stderr; this program writes
+//     only the JSON to stdout).
+
+using System.Diagnostics;
+using System.Text.Json;
+using SignalWire.Agent;
+using SignalWire.Skills;
+
+static void Die(string msg)
+{
+    Console.Error.WriteLine($"emit-skills: {msg}");
+    Environment.Exit(1);
+}
+
+// ── Load the shared corpus via the porting-sdk python script ───────────────
+// porting-sdk resolved via $PORTING_SDK / $PORTING_SDK_PATH or sibling ../porting-sdk.
+static string ResolveCorpusScript()
+{
+    var bases = new List<string>();
+    foreach (var var in new[] { "PORTING_SDK", "PORTING_SDK_PATH" })
+    {
+        var v = Environment.GetEnvironmentVariable(var);
+        if (!string.IsNullOrEmpty(v))
+        {
+            bases.Add(v);
+        }
+    }
+    bases.Add(Path.Combine(Directory.GetCurrentDirectory(), "..", "porting-sdk"));
+    foreach (var b in bases)
+    {
+        var script = Path.Combine(b, "scripts", "skill_contract_corpus.py");
+        if (File.Exists(script))
+        {
+            return script;
+        }
+    }
+    Die("cannot locate porting-sdk/scripts/skill_contract_corpus.py "
+        + "(set PORTING_SDK / PORTING_SDK_PATH or clone porting-sdk adjacent)");
+    return ""; // unreachable
+}
+
+var corpusScript = ResolveCorpusScript();
+var psi = new ProcessStartInfo("python3", $"\"{corpusScript}\"")
+{
+    RedirectStandardOutput = true,
+    RedirectStandardError = true,
+    UseShellExecute = false,
+};
+var proc = Process.Start(psi) ?? throw new InvalidOperationException("failed to launch python3");
+var corpusJson = proc.StandardOutput.ReadToEnd();
+proc.WaitForExit();
+if (proc.ExitCode != 0)
+{
+    Die($"corpus script failed: {proc.StandardError.ReadToEnd()}");
+}
+
+using var corpusDoc = JsonDocument.Parse(corpusJson);
+var corpus = corpusDoc.RootElement.GetProperty("corpus");
+
+// ── For each covered skill: instantiate, register, read tools back ─────────
+var registry = SkillRegistry.Instance;
+var result = new Dictionary<string, List<object>>();
+
+foreach (var entry in corpus.EnumerateArray())
+{
+    var id = entry.GetProperty("id").GetString()!;
+    var skillName = entry.GetProperty("skill").GetString()!;
+    var config = JsonConfigToDict(entry.GetProperty("config"));
+
+    var factory = registry.GetFactory(skillName);
+    if (factory is null)
+    {
+        Die($"no registered factory for covered skill '{skillName}'");
+    }
+    var skill = factory!();
+
+    var agent = new AgentBase(new AgentOptions { Name = "emit-skills", Route = "/emit" });
+    skill.Wire(agent, config);
+    if (!skill.Setup(agent, config))
+    {
+        Die($"skill '{skillName}' Setup() returned false with the corpus config "
+            + "— config drift between the corpus and the port.");
+    }
+    skill.RegisterTools(agent);
+
+    var contracts = new List<object>();
+    foreach (var def in agent.Tools)
+    {
+        var name = def.TryGetValue("function", out var n) ? n as string : null;
+        if (name is null)
+        {
+            continue;
+        }
+        object parameters = def.TryGetValue("argument", out var arg)
+            ? arg
+            : new Dictionary<string, object> { ["type"] = "object", ["properties"] = new Dictionary<string, object>() };
+        contracts.Add(new Dictionary<string, object> { ["name"] = name, ["parameters"] = parameters });
+    }
+    result[id] = contracts;
+}
+
+var opts = new JsonSerializerOptions { Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
+Console.WriteLine(JsonSerializer.Serialize(result, opts));
+
+// Convert the corpus JSON config object into the Dictionary<string,object>
+// shape skills expect (recursively, matching how the platform hands config in).
+static Dictionary<string, object> JsonConfigToDict(JsonElement obj)
+{
+    var dict = new Dictionary<string, object>();
+    foreach (var prop in obj.EnumerateObject())
+    {
+        dict[prop.Name] = JsonToObject(prop.Value);
+    }
+    return dict;
+}
+
+static object JsonToObject(JsonElement el) => el.ValueKind switch
+{
+    JsonValueKind.Object => JsonConfigToDict(el),
+    JsonValueKind.Array => JsonArrayToList(el),
+    JsonValueKind.String => el.GetString()!,
+    JsonValueKind.Number => el.TryGetInt64(out var l) ? l : el.GetDouble(),
+    JsonValueKind.True => true,
+    JsonValueKind.False => false,
+    _ => null!,
+};
+
+// Match how the platform hands config to skills: an array of objects arrives as
+// List<Dictionary<string,object>> (skills pattern-match on that exact type, e.g.
+// info_gatherer's `questions`, play_background's `files`). A non-object array
+// stays List<object>.
+static object JsonArrayToList(JsonElement el)
+{
+    var items = el.EnumerateArray().Select(JsonToObject).ToList();
+    if (items.Count > 0 && items.All(x => x is Dictionary<string, object>))
+    {
+        return items.Cast<Dictionary<string, object>>().ToList();
+    }
+    return items;
+}


### PR DESCRIPTION
## What

Brings signalwire-dotnet from **6 cross-port gates to 11**, matching the other ports, with the burndown each new gate requires.

Governing principle (locked cross-port): **language idiom drives type/shape, not parity.** Every analyzer rule that is a genuinely useful standing signal is ON and burned to zero (burndown cost is not a disqualifier); a rule is suppressed only where obeying it would change the SWAIG wire bytes / a wire token. Where an idiomatic shape diverges from Python's signature, the parity checker is taught the equivalence rather than the code de-idiomatized.

## New gates (`scripts/run-ci.sh`)
- **FMT** — `dotnet format whitespace` (local auto-fix; CI `--verify-no-changes`).
- **LINT** — clean analyzer build. `Directory.Build.props` enables analyzers (`AnalysisMode=All`, `TreatWarningsAsErrors`) for the shipped library only; `.editorconfig` carries per-rule severities (only CA1716/CA1724 off as low-value; everything else burned to zero).
- **DOC-AUDIT** + **SURFACE-DIFF** — porting-sdk `audit_docs.py` / `diff_port_surface.py`.
- **SKILL-CONTRACT** — porting-sdk `diff_skill_contracts.py` via new `tools/EmitSkills` + `scripts/emit-skills.sh` (sibling of EmitCorpus/emit-corpus.sh).

## LINT burndown (~876 CA warnings → 0, idiomatic, ~55 src files)
- `CA1002` `List<T>` → `IReadOnlyList<T>` on the public surface (DRIFT-safe — the adapter maps `IReadOnlyList`/`IReadOnlyCollection`/`ReadOnlyCollection` → `list<T>`; the `IReadOnlyCollection` mapping was added to `scripts/enumerate_signatures.py`).
- `CA1062` null-guards; `CA1305/07/08/10` culture/ordinal string ops; `CA1854` TryGetValue; `CA1032` exception ctors; and the perf/correctness tail (CA1805/1822/1823/1849/1859/1861/1862/1869/1508/1510/2000/2016/2025).
- Suppressed (member-level, with rationale) only where obeying changes the wire or fights the cross-port surface: `CA1054/55/56` (URLs are wire strings), `CA1024/1721` (`get_*` accessors match the cross-port surface), `CA1031` (handler-boundary/best-effort catches), `CA1308` (lowercase hex/header is the wire form), `CA1051/CA1002` on subclass-shared protected fields.

## SKILL-CONTRACT fixes (13 covered contracts match Python; 4 dynamic skipped)
- `Service.DefineTool` now **lifts** a per-property `"required": true` into the top-level JSON-Schema `required` array (`NormalizeParameters`) — the per-property flag never reached the wire before (same structural gap fixed in the Rust port). Corrects spider's `required` globally.
- Removed `required` Python omits (math, wikipedia_search, web_search, datasphere, info_gatherer, google_maps' raw DataMap dicts); removed the spurious `enum` on swml_transfer's `transfer_type`; added google_maps `lookup_address`'s missing `bias_lat`/`bias_lng` params.

## Safety
- **EMISSION stays 81/81 byte-identical** — the idiomatic burndown did not change the wire.
- **DRIFT** + **SURFACE-DIFF** green — idiomatic shapes canonicalize via the adapter/aliases.
- **All 1175 tests pass** on net8.0/net9.0/net10.0. Tests touching the changed surface were updated to the new (correct) shapes, not the code reverted.
- Full 11-gate `run-ci.sh` → `==> CI PASS` locally.

No porting-sdk change required (the adapter change is dotnet-local; `diff_skill_contracts.py` is already on porting-sdk main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)