### PR TITLE
fix(tests): raise REST mock control-plane HTTP timeout 5s->30s for load

### DIFF
--- a/tests/MockTest.cs
+++ b/tests/MockTest.cs
@@ -41,7 +41,15 @@ public static class MockTest
     public const int ReservedControlPlanePort = 9784;
 
     private static readonly TimeSpan StartupTimeout = TimeSpan.FromSeconds(30);
-    private static readonly TimeSpan HttpTimeout = TimeSpan.FromSeconds(5);
+    // Control-plane calls (journal/scenario) hit the shared mock over HTTP. A
+    // healthy mock answers in milliseconds, but under heavy concurrent load —
+    // e.g. the porting-sdk cross-port matrix running every port's suite plus
+    // this assembly's now-parallel tests on one runner — a single GET can stall
+    // past a tight budget and surface as a TaskCanceledException / disposed
+    // NetworkStream (seen on UpdateRecording_JournalRecordsPostWithStatus). 5s
+    // was too tight; match the relay harness's 30s (RelayMockTest.cs). The
+    // timeout only bites pathological load, so a generous value is correct.
+    private static readonly TimeSpan HttpTimeout = TimeSpan.FromSeconds(30);
 
     private static readonly object StateLock = new();
     private static Harness? _sharedHarness;


### PR DESCRIPTION
## Problem
The REST mock harness (`tests/MockTest.cs`) used a **5-second** `HttpClient.Timeout` for control-plane calls (journal/scenario). Under the porting-sdk cross-port matrix's heavy concurrent load — every port's suite plus this assembly's now-parallel tests on one CI runner — a single `GET /__mock__/journal` stalled past 5s and surfaced as:

```
System.Threading.Tasks.TaskCanceledException : The request was canceled due to
the configured HttpClient.Timeout of 5 seconds elapsing.
---- ... ObjectDisposedException : Cannot access a disposed object.
     Object name: 'System.Net.Sockets.NetworkStream'.
  at MockTest.JournalApi.All() in tests/MockTest.cs:line 245
  at CompatConferencesMockTest.UpdateRecording_JournalRecordsPostWithStatus()
```

Per-repo CI's lighter load never triggered it; the cross-port matrix did. Real load-induced defect, not a flake.

## Fix
Raise the REST harness `HttpTimeout` from 5s to **30s** — matching the relay harness (`RelayMockTest.cs:37` already uses 30s for the same kind of control-plane call; the REST side simply wasn't brought in line). A healthy mock answers in milliseconds, so the timeout only bites pathological load; a generous value is correct. The separate 2s startup *probe* is unchanged (intentionally short).

Test-infra only — no product code change.

## Verification (under 3× `yes` CPU load, net10.0)
- `CompatConferencesMockTest` (the failing class): **3/3** runs, 24 tests each.
- Full `RestMock` suite: **212/212**, deterministic.
- Release build clean (warnings-as-errors gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)