### PR TITLE
feat(security): port the 3 security_utils (filter_sensitive_headers, redact_url, is_valid_hostname)

### DIFF
--- a/PORT_ADDITIONS.md
+++ b/PORT_ADDITIONS.md
@@ -882,6 +882,10 @@ signalwire.core.security.webhook_middleware.WebhookValidationMiddleware: dotnet_
 signalwire.core.security.webhook_validator.WebhookValidator: dotnet_idiom_class_wrapper: static class containing validator functions (Python keeps them at module level)
 signalwire.core.security.webhook_validator.WebhookValidator.validate_request: dotnet_idiom_class_wrapper: see WebhookValidator class entry
 signalwire.core.security.webhook_validator.WebhookValidator.validate_webhook_signature: dotnet_idiom_class_wrapper: see WebhookValidator class entry
+signalwire.core.security.security_utils.SecurityUtils: dotnet_idiom_class_wrapper: static class containing the security-hygiene functions (Python keeps them at module level)
+signalwire.core.security.security_utils.SecurityUtils.filter_sensitive_headers: dotnet_idiom_class_wrapper: see SecurityUtils class entry
+signalwire.core.security.security_utils.SecurityUtils.redact_url: dotnet_idiom_class_wrapper: see SecurityUtils class entry
+signalwire.core.security.security_utils.SecurityUtils.is_valid_hostname: dotnet_idiom_class_wrapper: see SecurityUtils class entry
 
 ### Tier-3 typed RELAY state enums + Device (idiom: type the knowable shape alongside the parity string)
 

--- a/PORT_OMISSIONS.md
+++ b/PORT_OMISSIONS.md
@@ -1115,3 +1115,6 @@ signalwire.core.swml_service.SWMLService.security: .NET keeps this as private/in
 signalwire.core.swml_service.SWMLService.verb_registry: .NET keeps this as private/internal state; Python exposes it as a @property accessor for introspection
 signalwire.core.security.webhook_validator.validate_webhook_signature: idiomatic_divergence: implemented as static method on the WebhookValidator class (language idiom); see PORT_ADDITIONS.md
 signalwire.core.security.webhook_validator.validate_request: idiomatic_divergence: implemented as static method on the WebhookValidator class (language idiom); see PORT_ADDITIONS.md
+signalwire.core.security.security_utils.filter_sensitive_headers: idiomatic_divergence: implemented as static method SecurityUtils.FilterSensitiveHeaders (language idiom); see PORT_ADDITIONS.md
+signalwire.core.security.security_utils.redact_url: idiomatic_divergence: implemented as static method SecurityUtils.RedactUrl (language idiom); see PORT_ADDITIONS.md
+signalwire.core.security.security_utils.is_valid_hostname: idiomatic_divergence: implemented as static method SecurityUtils.IsValidHostname (language idiom); see PORT_ADDITIONS.md

--- a/port_signatures.json
+++ b/port_signatures.json
@@ -4666,6 +4666,40 @@
         }
       }
     },
+    "signalwire.core.security.security_utils": {
+      "functions": {
+        "filter_sensitive_headers": {
+          "params": [
+            {
+              "name": "headers",
+              "type": "optional<dict<string,string>>",
+              "required": true
+            }
+          ],
+          "returns": "dict<string,string>"
+        },
+        "is_valid_hostname": {
+          "params": [
+            {
+              "name": "host",
+              "type": "optional<string>",
+              "required": true
+            }
+          ],
+          "returns": "bool"
+        },
+        "redact_url": {
+          "params": [
+            {
+              "name": "url",
+              "type": "optional<string>",
+              "required": true
+            }
+          ],
+          "returns": "optional<string>"
+        }
+      }
+    },
     "signalwire.core.security.session_manager": {
       "classes": {
         "SessionManager": {

--- a/port_surface.json
+++ b/port_surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_from": "signalwire-dotnet @ 43ed87087d784d9521619c5f59af5febfcc6580e",
+  "generated_from": "signalwire-dotnet @ 1cedd1f0b640ab7b23b26beeebb6f3986af08e65",
   "modules": {
     "signalwire.agent.agent_options": {
       "classes": {
@@ -384,6 +384,16 @@
           "render_xml",
           "to_dict",
           "to_json"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.core.security.security_utils": {
+      "classes": {
+        "SecurityUtils": [
+          "filter_sensitive_headers",
+          "is_valid_hostname",
+          "redact_url"
         ]
       },
       "functions": []

--- a/scripts/enumerate_signatures.py
+++ b/scripts/enumerate_signatures.py
@@ -564,6 +564,10 @@ def collect(raw: dict, aliases: dict) -> tuple[dict, list]:
         # ``signalwire.core.security.webhook_validator`` functions
         # (``validate_webhook_signature`` and ``validate_request``).
         ("signalwire.core.security.webhook_validator", "WebhookValidator"): None,
+        # SecurityUtils's static methods mirror Python's module-level
+        # ``signalwire.core.security.security_utils`` free functions
+        # (``filter_sensitive_headers`` / ``redact_url`` / ``is_valid_hostname``).
+        ("signalwire.core.security.security_utils", "SecurityUtils"): None,
     }
     for (mod, cls), allowed in STATIC_TO_FREE_FN.items():
         cls_entry = out_modules.get(mod, {}).get("classes", {}).get(cls)

--- a/scripts/enumerate_surface.py
+++ b/scripts/enumerate_surface.py
@@ -80,6 +80,11 @@ CLASS_MODULE_MAP: dict[str, str] = {
     # ``signalwire.core.security.webhook_validator`` to mirror Python's
     # module-level ``validate_webhook_signature`` / ``validate_request``.
     "WebhookValidator": "signalwire.core.security.webhook_validator",
+    # SecurityUtils is a static helper class in C# whose methods are projected
+    # to free functions in ``signalwire.core.security.security_utils`` to mirror
+    # Python's module-level ``filter_sensitive_headers`` / ``redact_url`` /
+    # ``is_valid_hostname``.
+    "SecurityUtils": "signalwire.core.security.security_utils",
     # WebhookValidationMiddleware is a port-only adapter (Python ships a
     # FastAPI dependency-factory function instead). Document the addition
     # in PORT_ADDITIONS.md and place the .NET class under the parallel

--- a/src/SignalWire/Security/SecurityUtils.cs
+++ b/src/SignalWire/Security/SecurityUtils.cs
@@ -1,0 +1,108 @@
+// Copyright (c) 2025 SignalWire. Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+//
+// Standalone security hygiene utilities.
+//
+// These mirror the Python reference's
+// ``signalwire.core.security.security_utils`` free functions
+// (filter_sensitive_headers, redact_url, is_valid_hostname) — themselves a
+// mirror of the TypeScript SDK's ``SecurityUtils`` — so the same protections
+// (keeping credentials out of user callbacks and logs, reusable hostname
+// validation) are available in every port.
+//
+// Idiom note: C# has no module-level free functions, so the three functions
+// are exposed as PascalCase static methods on this ``SecurityUtils`` class.
+// The signature enumerator projects them back to the canonical
+// ``signalwire.core.security.security_utils.{filter_sensitive_headers,
+// redact_url, is_valid_hostname}`` free-function paths (see
+// scripts/enumerate_signatures.py STATIC_TO_FREE_FN).
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
+
+namespace SignalWire.Security;
+
+/// <summary>
+/// Standalone security hygiene helpers: strip credential-bearing headers
+/// before they reach user callbacks/logs, mask passwords embedded in URLs,
+/// and a reusable character-level hostname sanity check. Mirrors the Python
+/// reference's <c>signalwire.core.security.security_utils</c> module.
+/// </summary>
+public static class SecurityUtils
+{
+    // Header names whose values are credentials/secrets and must never be
+    // handed to user callbacks or written to logs. Compared case-insensitively.
+    private static readonly HashSet<string> SensitiveHeaders = new(System.StringComparer.OrdinalIgnoreCase)
+    {
+        "authorization",
+        "cookie",
+        "x-api-key",
+        "proxy-authorization",
+        "set-cookie",
+    };
+
+    // URL credentials: ``://user:secret@host`` -> ``://user:****@host``.
+    private static readonly Regex UrlCredentialsRe = new(
+        "://([^:@/]+):([^@/]+)@", RegexOptions.Compiled);
+
+    // Hostnames must not contain whitespace, slashes, or control characters.
+    private static readonly Regex HostnameRejectRe = new(
+        "[\\s/\\\\\\x00-\\x1f\\x7f]", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Return a copy of <paramref name="headers"/> with sensitive
+    /// (credential-bearing) headers removed, so request headers can be safely
+    /// passed to user callbacks. Keys are preserved as given; the sensitivity
+    /// check is case-insensitive. A null/empty input yields an empty map.
+    /// </summary>
+    public static Dictionary<string, string> FilterSensitiveHeaders(
+        IReadOnlyDictionary<string, string>? headers)
+    {
+        var result = new Dictionary<string, string>();
+        if (headers is null)
+        {
+            return result;
+        }
+        foreach (var kv in headers)
+        {
+            if (!SensitiveHeaders.Contains(kv.Key))
+            {
+                result[kv.Key] = kv.Value;
+            }
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Mask the password in a URL's userinfo before logging:
+    /// <c>https://user:secret@host/path</c> -> <c>https://user:****@host/path</c>.
+    /// A URL with no embedded credentials (or a null URL) is returned unchanged.
+    /// </summary>
+    [SuppressMessage("Usage", "CA1054", Justification = "URL is treated as an opaque log/wire string and rewritten textually; a Uri round-trip would normalize/encode it and defeat the redaction's purpose of returning the original string with only the password masked.")]
+    [SuppressMessage("Usage", "CA1055", Justification = "Returns the input URL string with only the password masked; a System.Uri return would normalize/encode the string and defeat the textual redaction (and lose any non-Uri input that is passed through unchanged).")]
+    public static string? RedactUrl(string? url)
+    {
+        if (url is null)
+        {
+            return url;
+        }
+        return UrlCredentialsRe.Replace(url, "://$1:****@");
+    }
+
+    /// <summary>
+    /// Standalone hostname sanity check: reject empty hosts and any host
+    /// containing whitespace, slashes, backslashes, or control characters.
+    /// This is the reusable character-level check, independent of the fuller
+    /// <see cref="SignalWire.Utils.UrlValidator.ValidateUrl"/> (which also does
+    /// scheme checks, DNS resolution, and private-IP blocking).
+    /// </summary>
+    public static bool IsValidHostname(string? host)
+    {
+        if (string.IsNullOrEmpty(host))
+        {
+            return false;
+        }
+        return !HostnameRejectRe.IsMatch(host);
+    }
+}

--- a/tests/Security/SecurityUtilsTest.cs
+++ b/tests/Security/SecurityUtilsTest.cs
@@ -1,0 +1,188 @@
+// Copyright (c) 2025 SignalWire. Licensed under the MIT License.
+//
+// Tests for SignalWire.Security.SecurityUtils.
+//
+// Cross-language SDK contract: every port implements the three security
+// hygiene helpers (filter_sensitive_headers, redact_url, is_valid_hostname)
+// with identical behavior to the Python reference
+// (signalwire-python/signalwire/signalwire/core/security/security_utils.py).
+// These assertions mirror that reference's documented behavior.
+
+using System.Collections.Generic;
+using Xunit;
+using SignalWire.Security;
+
+namespace SignalWire.Tests.Security;
+
+public class SecurityUtilsTest
+{
+    // =====================================================================
+    // FilterSensitiveHeaders
+    // =====================================================================
+
+    [Fact]
+    public void FilterSensitiveHeaders_RemovesAllSensitiveKeysCaseInsensitively()
+    {
+        var headers = new Dictionary<string, string>
+        {
+            ["Authorization"] = "Bearer secret-token",
+            ["Cookie"] = "session=abc",
+            ["X-API-Key"] = "key-123",
+            ["Proxy-Authorization"] = "Basic xyz",
+            ["Set-Cookie"] = "a=b",
+            ["Content-Type"] = "application/json",
+            ["X-Request-Id"] = "req-42",
+        };
+
+        var filtered = SecurityUtils.FilterSensitiveHeaders(headers);
+
+        // Sensitive keys are gone regardless of original casing.
+        Assert.False(filtered.ContainsKey("Authorization"));
+        Assert.False(filtered.ContainsKey("Cookie"));
+        Assert.False(filtered.ContainsKey("X-API-Key"));
+        Assert.False(filtered.ContainsKey("Proxy-Authorization"));
+        Assert.False(filtered.ContainsKey("Set-Cookie"));
+
+        // Non-sensitive keys are preserved AS GIVEN (original casing + value).
+        Assert.Equal(2, filtered.Count);
+        Assert.Equal("application/json", filtered["Content-Type"]);
+        Assert.Equal("req-42", filtered["X-Request-Id"]);
+    }
+
+    [Fact]
+    public void FilterSensitiveHeaders_MatchesSensitiveKeysRegardlessOfInputCasing()
+    {
+        var headers = new Dictionary<string, string>
+        {
+            ["AUTHORIZATION"] = "Bearer x",
+            ["cookie"] = "y",
+            ["x-api-KEY"] = "z",
+            ["Keep-Me"] = "ok",
+        };
+
+        var filtered = SecurityUtils.FilterSensitiveHeaders(headers);
+
+        Assert.Single(filtered);
+        Assert.Equal("ok", filtered["Keep-Me"]);
+    }
+
+    [Fact]
+    public void FilterSensitiveHeaders_ReturnsNewMap_DoesNotMutateInput()
+    {
+        var headers = new Dictionary<string, string>
+        {
+            ["Authorization"] = "Bearer x",
+            ["Accept"] = "*/*",
+        };
+
+        var filtered = SecurityUtils.FilterSensitiveHeaders(headers);
+
+        // Input is untouched; result is a distinct object.
+        Assert.NotSame(headers, filtered);
+        Assert.Equal(2, headers.Count);
+        Assert.True(headers.ContainsKey("Authorization"));
+        Assert.Single(filtered);
+    }
+
+    [Fact]
+    public void FilterSensitiveHeaders_NullInput_ReturnsEmptyMap()
+    {
+        var filtered = SecurityUtils.FilterSensitiveHeaders(null);
+        Assert.NotNull(filtered);
+        Assert.Empty(filtered);
+    }
+
+    [Fact]
+    public void FilterSensitiveHeaders_EmptyInput_ReturnsEmptyMap()
+    {
+        var filtered = SecurityUtils.FilterSensitiveHeaders(
+            new Dictionary<string, string>());
+        Assert.Empty(filtered);
+    }
+
+    // =====================================================================
+    // RedactUrl
+    // =====================================================================
+
+    [Fact]
+    public void RedactUrl_MasksPasswordInUserinfo()
+    {
+        Assert.Equal(
+            "https://user:****@host/path",
+            SecurityUtils.RedactUrl("https://user:secret@host/path"));
+    }
+
+    [Fact]
+    public void RedactUrl_PreservesUsername()
+    {
+        var redacted = SecurityUtils.RedactUrl("https://alice:hunter2@example.com:8080/x?q=1");
+        Assert.Equal("https://alice:****@example.com:8080/x?q=1", redacted);
+        Assert.Contains("alice", redacted);
+        Assert.DoesNotContain("hunter2", redacted);
+    }
+
+    [Fact]
+    public void RedactUrl_NoCredentials_ReturnedUnchanged()
+    {
+        const string url = "https://example.com/path?token=visible";
+        Assert.Equal(url, SecurityUtils.RedactUrl(url));
+    }
+
+    [Fact]
+    public void RedactUrl_NullInput_ReturnedAsIs()
+    {
+        Assert.Null(SecurityUtils.RedactUrl(null));
+    }
+
+    [Fact]
+    public void RedactUrl_NonUrlString_ReturnedUnchanged()
+    {
+        Assert.Equal("not a url", SecurityUtils.RedactUrl("not a url"));
+    }
+
+    // =====================================================================
+    // IsValidHostname
+    // =====================================================================
+
+    [Theory]
+    [InlineData("example.com")]
+    [InlineData("sub.domain.example.com")]
+    [InlineData("localhost")]
+    [InlineData("192.168.1.1")]
+    [InlineData("host-with-dash")]
+    public void IsValidHostname_AcceptsCleanHostnames(string host)
+    {
+        Assert.True(SecurityUtils.IsValidHostname(host));
+    }
+
+    [Fact]
+    public void IsValidHostname_EmptyOrNull_IsRejected()
+    {
+        Assert.False(SecurityUtils.IsValidHostname(""));
+        Assert.False(SecurityUtils.IsValidHostname(null));
+    }
+
+    [Theory]
+    [InlineData("host with space")]
+    [InlineData("host\twith\ttab")]
+    [InlineData("host/with/slash")]
+    [InlineData("host\\with\\backslash")]
+    [InlineData("host\nnewline")]
+    [InlineData("host\rcarriage")]
+    public void IsValidHostname_RejectsWhitespaceSlashesAndBackslashes(string host)
+    {
+        Assert.False(SecurityUtils.IsValidHostname(host));
+    }
+
+    [Theory]
+    [InlineData(0x00)]   // NUL — bottom of the 0x00-0x1f control range
+    [InlineData(0x1f)]   // unit separator — top of the 0x00-0x1f control range
+    [InlineData(0x7f)]   // DEL
+    public void IsValidHostname_RejectsControlCharacters(int codePoint)
+    {
+        // Build the string in code so the control byte is unambiguous and
+        // avoids brittle string-literal escaping in the test source.
+        var host = "host" + (char)codePoint + "name";
+        Assert.False(SecurityUtils.IsValidHostname(host));
+    }
+}


### PR DESCRIPTION
## What

Ports the 3 new `security_utils` free functions from the Python reference
(`signalwire.core.security.security_utils`) to the .NET SDK, clearing the
DRIFT gate after the Python reference added them. These mirror the TypeScript
SDK's `SecurityUtils`.

| Canonical (Python) | .NET (this PR) |
|---|---|
| `filter_sensitive_headers(headers)` | `SecurityUtils.FilterSensitiveHeaders(headers)` |
| `redact_url(url)` | `SecurityUtils.RedactUrl(url)` |
| `is_valid_hostname(host)` | `SecurityUtils.IsValidHostname(host)` |

## Behavior (functional parity with the Python oracle)

- **FilterSensitiveHeaders** — returns a new map that is a copy of the input
  with credential-bearing keys removed (`authorization`, `cookie`,
  `x-api-key`, `proxy-authorization`, `set-cookie`), compared
  case-insensitively. Null/empty input -> empty map. Kept keys preserved with
  original casing and value. Does not mutate the input.
- **RedactUrl** — masks the password in a URL's userinfo
  (`https://user:secret@host/path` -> `https://user:****@host/path`).
  A URL with no embedded credentials (or `null`) is returned unchanged.
- **IsValidHostname** — rejects empty hosts and any host containing
  whitespace, slashes, backslashes, or control chars (`[\s/\\\x00-\x1f\x7f]`);
  otherwise true.

## Idiom adjustments (legitimate per spec)

C# has no module-level free functions, so the three functions are PascalCase
static methods on a new `SignalWire.Security.SecurityUtils` class. This
mirrors the existing `WebhookValidator` / `UrlValidator` treatment:

- `scripts/enumerate_signatures.py` `STATIC_TO_FREE_FN` projects the static
  methods back to the canonical `signalwire.core.security.security_utils.*`
  free-function paths (so the **DRIFT** gate sees free functions and matches
  the reference, then drops the class).
- `scripts/enumerate_surface.py` `CLASS_MODULE_MAP` places `SecurityUtils`
  at `signalwire.core.security.security_utils`.
- The surface idiom (class+methods vs free functions) is reconciled in
  `PORT_ADDITIONS.md` (the `SecurityUtils` class + its 3 methods) and
  `PORT_OMISSIONS.md` (the 3 canonical free functions), exactly as
  `WebhookValidator` does.

## Tests

New `tests/Security/SecurityUtilsTest.cs` with real assertions per function:
case-insensitive sensitive-key removal, no-mutation/distinct-map, null/empty
inputs, password masking + username preservation, no-credentials/null
pass-through, clean-hostname acceptance, and rejection of
whitespace/slashes/backslashes/control chars (NUL, unit-sep, DEL).

## Verification

`bash scripts/run-ci.sh` -> **CI PASS** (all 11 gates: TEST, SIGNATURES,
DRIFT, SURFACE-FRESH, NO-CHEAT, EMISSION, FMT, LINT, DOC-AUDIT, SURFACE-DIFF,
SKILL-CONTRACT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhzeysbfURBuHL5Sn7Sjau
