### PR TITLE
fix(agent): behavior parity bundle (#190/#191/#185/#182)

### DIFF
--- a/src/SignalWire/Agent/AgentBase.cs
+++ b/src/SignalWire/Agent/AgentBase.cs
@@ -299,6 +299,12 @@ public class AgentBase : Service
         string body = "",
         IReadOnlyList<string>? bullets = null)
     {
+        // Auto-create the parent section when it does not yet exist, matching
+        // TypeScript PomBuilder.addSubsection / Python prompt_add_subsection.
+        if (!PromptHasSection(parentTitle))
+        {
+            PromptAddSection(parentTitle);
+        }
         foreach (var section in _pomSections)
         {
             if ((string)section["title"] == parentTitle)
@@ -333,6 +339,12 @@ public class AgentBase : Service
         string? bullet = null,
         IReadOnlyList<string>? bullets = null)
     {
+        // Auto-create the section when it does not yet exist, matching
+        // TypeScript PomBuilder.addToSection / Python prompt_add_to_section.
+        if (!PromptHasSection(title))
+        {
+            PromptAddSection(title);
+        }
         foreach (var section in _pomSections)
         {
             if ((string)section["title"] == title)
@@ -380,7 +392,14 @@ public class AgentBase : Service
         {
             return _pomSections;
         }
-        return _promptText;
+        if (!string.IsNullOrEmpty(_promptText))
+        {
+            return _promptText;
+        }
+        // No raw text and no POM sections: emit the default fallback prompt,
+        // matching TypeScript (`You are ${name}, a helpful AI assistant.`) and
+        // Python (`PromptMixin.get_prompt`) rather than an empty string.
+        return $"You are {Name}, a helpful AI assistant.";
     }
 
     /// <summary>Return the raw prompt text if set, else null.
@@ -636,9 +655,22 @@ public class AgentBase : Service
         return this;
     }
 
+    /// <summary>
+    /// <b>MERGES</b> <paramref name="data"/> into the existing global_data
+    /// object. Despite the name this does NOT replace the existing object:
+    /// existing keys are preserved and incoming keys overwrite only on
+    /// collision. Matches the reference SDKs (TypeScript <c>setGlobalData</c> /
+    /// Python <c>set_global_data</c>), where skills and other callers each
+    /// contribute keys and a replacing assignment would silently clobber their
+    /// contributions. Identical in effect to <see cref="UpdateGlobalData"/>.
+    /// </summary>
     public AgentBase SetGlobalData(Dictionary<string, object> data)
     {
-        _globalData = data;
+        ArgumentNullException.ThrowIfNull(data);
+        foreach (var (key, value) in data)
+        {
+            _globalData[key] = value;
+        }
         return this;
     }
 
@@ -790,11 +822,56 @@ public class AgentBase : Service
         return this;
     }
 
+    /// <summary>
+    /// Replace the entire list of function includes, dropping any entry that
+    /// is not a valid include. A valid include has a truthy <c>url</c> and a
+    /// <c>functions</c> value that is a list. Invalid entries are filtered out
+    /// (matching TypeScript <c>setFunctionIncludes</c> and Python
+    /// <c>set_function_includes</c>, which keep only well-formed entries); a
+    /// warning is logged per dropped entry so a malformed include is caught
+    /// at registration rather than silently disappearing from the SWML.
+    /// </summary>
     public AgentBase SetFunctionIncludes(IReadOnlyList<Dictionary<string, object>> includes)
     {
         ArgumentNullException.ThrowIfNull(includes);
-        _functionIncludes = [.. includes];
+        var valid = new List<Dictionary<string, object>>(includes.Count);
+        foreach (var include in includes)
+        {
+            if (IsValidFunctionInclude(include))
+            {
+                valid.Add(include);
+            }
+            else
+            {
+                _agentLogger.Warn(
+                    "invalid_function_include_dropped: an entry passed to " +
+                    "SetFunctionIncludes is missing a 'url' or a list-valued " +
+                    "'functions' field and was dropped.");
+            }
+        }
+        _functionIncludes = valid;
         return this;
+    }
+
+    /// <summary>A function include is valid when it has a non-empty <c>url</c>
+    /// and a list-valued <c>functions</c> field, matching the reference SDKs'
+    /// filter.</summary>
+    private static bool IsValidFunctionInclude(Dictionary<string, object> include)
+    {
+        if (include is null)
+        {
+            return false;
+        }
+        if (!include.TryGetValue("url", out var url) || url is not string urlStr
+            || string.IsNullOrEmpty(urlStr))
+        {
+            return false;
+        }
+        if (!include.TryGetValue("functions", out var functions) || functions is not System.Collections.IList)
+        {
+            return false;
+        }
+        return true;
     }
 
     public AgentBase SetPromptLlmParams(Dictionary<string, object> parameters)

--- a/tests/AgentBaseTests.cs
+++ b/tests/AgentBaseTests.cs
@@ -589,8 +589,16 @@ public class AgentBaseTests : IDisposable
     public void SetFunctionIncludes()
     {
         var agent = MakeAgent();
-        agent.AddFunctionInclude(new Dictionary<string, object> { ["url"] = "https://first.com" });
-        agent.SetFunctionIncludes([new Dictionary<string, object> { ["url"] = "https://replaced.com" }]);
+        agent.AddFunctionInclude(new Dictionary<string, object>
+        {
+            ["url"] = "https://first.com",
+            ["functions"] = new List<string> { "a" },
+        });
+        agent.SetFunctionIncludes([new Dictionary<string, object>
+        {
+            ["url"] = "https://replaced.com",
+            ["functions"] = new List<string> { "b" },
+        }]);
 
         var ai = ExtractAiVerb(agent.RenderSwml());
         var swaig = (Dictionary<string, object>)ai["SWAIG"];
@@ -1015,6 +1023,122 @@ public class AgentBaseTests : IDisposable
         Assert.Same(agent, agent.SetWebHookUrl("http://x"));
         Assert.Same(agent, agent.SetPostPromptUrl("http://x"));
         Assert.Same(agent, agent.ManualSetProxyUrl("http://x"));
+    }
+
+    // =================================================================
+    //  Behavior parity bundle (#190 / #191 / #185 / #182)
+    // =================================================================
+
+    // #190: SetGlobalData MERGES incoming keys over existing rather than
+    // replacing the whole object, matching TypeScript setGlobalData /
+    // Python set_global_data.
+    [Fact]
+    public void SetGlobalData_MergesOverExisting_190()
+    {
+        var agent = MakeAgent();
+        agent.SetGlobalData(new Dictionary<string, object> { ["a"] = 1, ["b"] = 2 });
+        // Second call must NOT clobber prior keys; overlapping key wins.
+        agent.SetGlobalData(new Dictionary<string, object> { ["b"] = 99, ["c"] = 3 });
+
+        var ai = ExtractAiVerb(agent.RenderSwml());
+        var gd = (Dictionary<string, object>)ai["global_data"];
+        Assert.Equal(1, gd["a"]);   // preserved (would be lost under replace)
+        Assert.Equal(99, gd["b"]);  // overwritten on collision
+        Assert.Equal(3, gd["c"]);   // added
+    }
+
+    // #191: SetFunctionIncludes drops entries lacking a url or a list-valued
+    // functions field (matching TypeScript / Python filters) and warns per
+    // dropped entry.
+    [Fact]
+    public void SetFunctionIncludes_DropsInvalidAndWarns_191()
+    {
+        var agent = MakeAgent();
+        var originalErr = Console.Error;
+        var captured = new StringWriter();
+        Console.SetError(captured);
+        try
+        {
+            agent.SetFunctionIncludes(
+            [
+                new Dictionary<string, object>
+                {
+                    ["url"] = "https://valid.com",
+                    ["functions"] = new List<string> { "a" },
+                },
+                new Dictionary<string, object> { ["url"] = "https://no-functions.com" }, // missing functions
+                new Dictionary<string, object> { ["functions"] = new List<string> { "x" } }, // missing url
+            ]);
+        }
+        finally
+        {
+            Console.SetError(originalErr);
+        }
+
+        var ai = ExtractAiVerb(agent.RenderSwml());
+        var swaig = (Dictionary<string, object>)ai["SWAIG"];
+        var includes = (List<Dictionary<string, object>>)swaig["includes"];
+        Assert.Single(includes);
+        Assert.Equal("https://valid.com", includes[0]["url"]);
+
+        var log = captured.ToString();
+        // One warning per dropped entry (two invalid entries above).
+        var dropCount = log.Split("invalid_function_include_dropped").Length - 1;
+        Assert.Equal(2, dropCount);
+    }
+
+    // #185: GetPrompt emits the default fallback prompt when there is no raw
+    // text and no POM sections, matching TypeScript
+    // (`You are ${name}, a helpful AI assistant.`) and Python get_prompt.
+    [Fact]
+    public void GetPrompt_FallsBackToDefault_185()
+    {
+        var agent = new AgentBase(new AgentOptions
+        {
+            Name = "test-agent",
+            BasicAuthUser = "testuser",
+            BasicAuthPassword = "testpass",
+            UsePom = false,
+        });
+        // No SetPromptText, no POM sections.
+        var prompt = agent.GetPrompt();
+        Assert.IsType<string>(prompt);
+        Assert.Equal("You are test-agent, a helpful AI assistant.", prompt);
+    }
+
+    // #182: PromptAddToSection auto-creates the section when it does not exist
+    // (matching TypeScript PomBuilder.addToSection / Python
+    // prompt_add_to_section) instead of silently no-op'ing.
+    [Fact]
+    public void PromptAddToSection_AutoCreatesSection_182()
+    {
+        var agent = MakeAgent();
+        agent.PromptAddToSection("New Section", "Body text.", bullets: ["b1"]);
+
+        var sections = (List<Dictionary<string, object>>)agent.GetPrompt();
+        Assert.Single(sections);
+        Assert.Equal("New Section", sections[0]["title"]);
+        Assert.Equal("Body text.", sections[0]["body"]);
+        Assert.Equal(new List<string> { "b1" }, sections[0]["bullets"]);
+    }
+
+    // #182: PromptAddSubsection auto-creates the parent section when it does
+    // not exist (matching TypeScript PomBuilder.addSubsection / Python
+    // prompt_add_subsection) instead of silently no-op'ing.
+    [Fact]
+    public void PromptAddSubsection_AutoCreatesParent_182()
+    {
+        var agent = MakeAgent();
+        agent.PromptAddSubsection("New Parent", "Detail", "Detail body.");
+
+        var sections = (List<Dictionary<string, object>>)agent.GetPrompt();
+        Assert.Single(sections);
+        Assert.Equal("New Parent", sections[0]["title"]);
+        Assert.True(sections[0].ContainsKey("subsections"));
+        var subs = (List<Dictionary<string, object>>)sections[0]["subsections"];
+        Assert.Single(subs);
+        Assert.Equal("Detail", subs[0]["title"]);
+        Assert.Equal("Detail body.", subs[0]["body"]);
     }
 
     // =================================================================


### PR DESCRIPTION
## Summary

Four `AgentBase` behavior fixes, each verified against the **TypeScript** reference (the clean port) and confirmed against Python. Wire-neutral except the intended behavior changes.

| Issue | Fix | TS reference |
|---|---|---|
| #190 | `SetGlobalData` now **merges** incoming keys over existing instead of replacing the whole object | `setGlobalData` → `safeAssign(globalData, data)` (AgentBase.ts) / Python `set_global_data` |
| #191 | `SetFunctionIncludes` **drops** entries lacking a `url` or a list-valued `functions` field, warning per dropped entry | `setFunctionIncludes` filter `inc.url && Array.isArray(inc.functions)` / Python `set_function_includes` |
| #185 | `GetPrompt` emits the fallback `You are {name}, a helpful AI assistant.` when there is no raw text and no POM sections, instead of `""` | render fallback `prompt || \`You are ${name}, a helpful AI assistant.\`` / Python `PromptMixin.get_prompt` |
| #182 | `PromptAddToSection` and `PromptAddSubsection` **auto-create** the (parent) section when missing instead of silently no-op'ing | `PomBuilder.addToSection`/`addSubsection` (auto-create via `addSection`) / Python |

## Notes

- #190: existing `UpdateGlobalData` is the explicit-merge alias; `SetGlobalData` now matches it, as the reference SDKs intend (a replacing `SetGlobalData` would clobber skill-contributed keys). True-replace has no reference counterpart, so none was added.
- #191: TS/Python filter silently; this port adds a per-drop `Warn` using the existing registration-warn idiom already established for internal fillers (entries the runtime silently ignores). The kept set matches TS/Python exactly.
- #185: fix is scoped to the `GetPrompt()` accessor (parity with Python `get_prompt()`); the SWML wire path is unchanged.

## Tests (TDD: fails-before / passes-after, all proven)

- `SetGlobalData_MergesOverExisting_190`
- `SetFunctionIncludes_DropsInvalidAndWarns_191`
- `GetPrompt_FallsBackToDefault_185`
- `PromptAddToSection_AutoCreatesSection_182`
- `PromptAddSubsection_AutoCreatesParent_182`
- Existing `SetFunctionIncludes` test updated to use well-formed includes.

Reverting the source to `origin/main` makes the new tests fail (`Single() Failure: 3 items`, `InvalidCastException`, `Expected: You are test-agent... Actual: <empty>`); restoring the fixes makes them pass.

## Verification

Full `bash scripts/run-ci.sh` is **green** — all gates: TEST (net8/9/10 sequential), DRIFT, SURFACE-FRESH, NO-CHEAT, REST-COVERAGE, SPEC-PARITY, EMISSION, FMT, LINT (analyzers + warnings-as-errors), DOC-AUDIT, SURFACE-DIFF, SKILL-CONTRACT. No public-surface drift (the new helper is private). No net10.0 RELAY-smoke timeout (#68) observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhzeysbfURBuHL5Sn7Sjau