### PR TITLE
docs: audit and fix README for accuracy and completeness

### DIFF
--- a/DOC_AUDIT_IGNORE.md
+++ b/DOC_AUDIT_IGNORE.md
@@ -49,6 +49,9 @@ FromSeconds: System.TimeSpan.FromSeconds
 GetRawText: System.Text.Json.JsonElement.GetRawText
 GetType: System.Object.GetType
 ReadAsStringAsync: System.Net.Http.HttpContent.ReadAsStringAsync
+ReadToEndAsync: System.IO.StreamReader.ReadToEndAsync
+ToDictionary: System.Linq ToDictionary operator
+WriteAsync: Microsoft.AspNetCore.Http.HttpResponse.WriteAsync / System.IO.TextWriter.WriteAsync
 Replace: System.Text.RegularExpressions.Regex.Replace / System.String.Replace
 SetEnvironmentVariable: System.Environment.SetEnvironmentVariable
 ToUpperInvariant: System.String.ToUpperInvariant

--- a/README.md
+++ b/README.md
@@ -123,14 +123,7 @@ var client = new Client(new Dictionary<string, string>
 client.OnCall(async (call, evt) =>
 {
     await call.AnswerAsync();
-    var action = await call.PlayAsync(media: new[]
-    {
-        new Dictionary<string, object>
-        {
-            ["type"]   = "tts",
-            ["params"] = new Dictionary<string, object> { ["text"] = "Welcome to SignalWire!" },
-        },
-    });
+    var action = call.PlayTts("Welcome to SignalWire!");
     await action.WaitAsync();
     await call.HangupAsync();
 });

--- a/README.md
+++ b/README.md
@@ -52,10 +52,21 @@ var agent = new AgentBase(new AgentOptions { Name = "my-agent", Route = "/agent"
 agent.AddLanguage("English", "en-US", "inworld.Mark");
 agent.PromptAddSection("Role", "You are a helpful assistant.");
 
-agent.DefineTool("get_time", "Get the current time", new { },
-    (args, rawData) => new FunctionResult($"The time is {DateTime.Now:HH:mm:ss}"));
+agent.DefineTool(
+    name:        "get_time",
+    description: "Get the current time",
+    parameters:  new Dictionary<string, object>(),
+    handler:     (args, rawData) => new FunctionResult($"The time is {DateTime.Now:HH:mm:ss}"));
 
 agent.Run();
+```
+
+Test SWAIG tools locally without a running server using the `swaig-test` CLI ([dotnet-script](https://github.com/dotnet-script/dotnet-script)) against a built assembly:
+
+```bash
+swaig-test --assembly path/to/MyAgent.dll --class My.Namespace.MyAgent --list-tools
+swaig-test --url http://user:pass@localhost:3000/agent --dump-swml
+swaig-test --url http://user:pass@localhost:3000/agent --exec get_time
 ```
 
 ### Agent Features
@@ -74,6 +85,24 @@ agent.Run();
 - **Security** -- auto-generated basic auth, function-specific HMAC tokens
 - **Serverless** -- Azure Functions, AWS Lambda, and auto-detection adapters
 
+### Agent Examples
+
+The [`examples/`](examples/) directory contains working C# examples:
+
+| Example | What it demonstrates |
+|---------|---------------------|
+| [SimpleAgent.cs](examples/SimpleAgent.cs) | POM prompts, SWAIG tools, multilingual support, summaries |
+| [ContextsDemo.cs](examples/ContextsDemo.cs) | Multi-step workflow with context switching and step navigation |
+| [DataMapDemo.cs](examples/DataMapDemo.cs) | Server-side API tools without webhooks |
+| [SkillsDemo.cs](examples/SkillsDemo.cs) | Loading built-in skills (datetime, math) |
+| [CallFlowAndActionsDemo.cs](examples/CallFlowAndActionsDemo.cs) | Call flow verbs, debug events, FunctionResult actions |
+| [SessionAndStateDemo.cs](examples/SessionAndStateDemo.cs) | Global data, post-prompt summaries, session state |
+| [MultiAgentServer.cs](examples/MultiAgentServer.cs) | Multiple agents on one server with `AgentServer` |
+| [LambdaAgent.cs](examples/LambdaAgent.cs) | AWS Lambda deployment |
+| [ComprehensiveDynamicAgent.cs](examples/ComprehensiveDynamicAgent.cs) | Per-request dynamic configuration, multi-tenant routing |
+
+See [examples/README.md](examples/README.md) for the full list organized by category.
+
 ---
 
 ## RELAY Client
@@ -83,28 +112,36 @@ Real-time call control and messaging over WebSocket. The RELAY client connects t
 ```csharp
 using SignalWire.Relay;
 
-var client = new RelayClient(new RelayOptions
+var client = new Client(new Dictionary<string, string>
 {
-    Project = "your-project-id",
-    Token = "your-token",
-    Host = "example.signalwire.com",
-    Contexts = ["default"],
+    ["project"]  = "your-project-id",
+    ["token"]    = "your-token",
+    ["host"]     = "example.signalwire.com",
+    ["contexts"] = "default",
 });
 
-client.OnCall(async call =>
+client.OnCall(async (call, evt) =>
 {
-    await call.Answer();
-    var action = await call.Play(new[] { new TtsMedia("Welcome to SignalWire!") });
-    await action.Wait();
-    await call.Hangup();
+    await call.AnswerAsync();
+    var action = await call.PlayAsync(media: new[]
+    {
+        new Dictionary<string, object>
+        {
+            ["type"]   = "tts",
+            ["params"] = new Dictionary<string, object> { ["text"] = "Welcome to SignalWire!" },
+        },
+    });
+    await action.WaitAsync();
+    await call.HangupAsync();
 });
 
-await client.Run();
+await client.ConnectAsync();
+await client.RunAsync();
 ```
 
-- 57+ calling methods (play, record, collect, detect, tap, stream, AI, conferencing, and more)
+- All calling methods: play, record, collect, connect, detect, fax, tap, stream, AI, conferencing, queues, and more
 - SMS/MMS messaging with delivery tracking
-- Action objects with `Wait()`, `Stop()`, `Pause()`, `Resume()`
+- Action objects with `WaitAsync()`, `Stop()`, `Pause()`, `Resume()`
 - Auto-reconnect with exponential backoff
 
 See the **[RELAY documentation](relay/README.md)** for the full guide, API reference, and examples.
@@ -120,14 +157,21 @@ using SignalWire.REST;
 
 var client = new RestClient("project-id", "token", "example.signalwire.com");
 
-client.Fabric.AiAgents.Create(new { name = "Support Bot" });
-client.Calling.Play(callId, new { play = new[] { new { type = "tts", text = "Hello!" } } });
-client.PhoneNumbers.List(new { area_code = "512" });
-client.Datasphere.Documents.Search(new { query_string = "billing policy" });
+await client.Fabric.AiAgents.CreateAsync(new Dictionary<string, object?>
+{
+    ["name"]   = "Support Bot",
+    ["prompt"] = new Dictionary<string, object?> { ["text"] = "You are helpful." },
+});
+await client.PhoneNumbers.SearchAsync(new Dictionary<string, string> { ["area_code"] = "512" });
+await client.Datasphere.Documents.SearchAsync(new Dictionary<string, object?>
+{
+    ["query_string"] = "billing policy",
+});
 ```
 
-- 21 namespaced API surfaces: Fabric, Calling, Video, Datasphere, Compat, and more
-- HttpClient with connection pooling
+- 21 namespaced API surfaces: Fabric, Calling, Video, Datasphere, Compat, Phone Numbers, SIP, Queues, Recordings, and more
+- `Task`-based async API throughout
+- `HttpClient` with connection pooling
 - Dictionary returns -- raw data, no wrapper objects
 
 See the **[REST documentation](rest/README.md)** for the full guide, API reference, and examples.
@@ -140,7 +184,47 @@ See the **[REST documentation](rest/README.md)** for the full guide, API referen
 dotnet add package SignalWire.Sdk
 ```
 
-Requires .NET 8.0+. Works with C#, F#, VB.NET, and any CLR language.
+Targets .NET 8.0, 9.0, and 10.0. Works with C#, F#, VB.NET, and any CLR language.
+
+## Documentation
+
+Full reference documentation is available at **[developer.signalwire.com/sdks/agents-sdk](https://developer.signalwire.com/sdks/agents-sdk)**.
+
+Guides are also available in the [`docs/`](docs/) directory:
+
+### Getting Started
+
+- [Agent Guide](docs/agent_guide.md) -- creating agents, prompt configuration, dynamic setup
+- [Architecture](docs/architecture.md) -- SDK architecture and core concepts
+- [SDK Features](docs/sdk_features.md) -- feature overview, SDK vs raw SWML comparison
+
+### Core Features
+
+- [SWAIG Reference](docs/swaig_reference.md) -- function results, actions, post_data lifecycle
+- [Contexts and Steps](docs/contexts_guide.md) -- structured workflows, navigation, gather mode
+- [DataMap Guide](docs/datamap_guide.md) -- serverless API tools without webhooks
+- [LLM Parameters](docs/llm_parameters.md) -- temperature, top_p, barge confidence tuning
+- [SWML Service Guide](docs/swml_service_guide.md) -- low-level construction of SWML documents
+
+### Skills and Extensions
+
+- [Skills System](docs/skills_system.md) -- built-in skills and the modular framework
+- [Third-Party Skills](docs/third_party_skills.md) -- creating and publishing custom skills
+- [MCP Integration](docs/mcp_integration.md) -- Model Context Protocol integration
+- [MCP Gateway Reference](docs/mcp_gateway_reference.md) -- bridging MCP servers into SWAIG
+- [Skills Parameter Schema](docs/skills_parameter_schema.md) -- skill parameter definitions
+
+### Deployment
+
+- [CLI Guide](docs/cli_guide.md) -- `swaig-test` command reference
+- [Cloud Functions](docs/cloud_functions_guide.md) -- Azure Functions and serverless deployment
+- [Configuration](docs/configuration.md) -- environment variables, SSL, proxy setup
+- [Security](docs/security.md) -- authentication and security model
+
+### Reference
+
+- [API Reference](docs/api_reference.md) -- complete class and method reference
+- [Web Service](docs/web_service.md) -- HTTP server and endpoint details
 
 ## Environment Variables
 
@@ -152,13 +236,23 @@ Requires .NET 8.0+. Works with C#, F#, VB.NET, and any CLR language.
 | `SWML_BASIC_AUTH_USER` | Agents | Basic auth username (default: auto-generated) |
 | `SWML_BASIC_AUTH_PASSWORD` | Agents | Basic auth password (default: auto-generated) |
 | `SWML_PROXY_URL_BASE` | Agents | Base URL when behind a reverse proxy |
+| `SWML_SSL_ENABLED` | Agents | Enable HTTPS (`true`, `1`, `yes`) |
+| `SWML_SSL_CERT_PATH` | Agents | Path to SSL certificate |
+| `SWML_SSL_KEY_PATH` | Agents | Path to SSL private key |
 | `SIGNALWIRE_LOG_LEVEL` | All | Logging level (`debug`, `info`, `warn`, `error`) |
 | `SIGNALWIRE_LOG_MODE` | All | Set to `off` to suppress all logging |
 
 ## Testing
 
 ```bash
+# Build the solution
+dotnet build
+
+# Run the full test suite (xUnit)
 dotnet test
+
+# Run a subset by fully-qualified name
+dotnet test --filter "FullyQualifiedName~LoggerTests"
 ```
 
 ## License

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -110,9 +110,22 @@ var client = new RestClient(
     space:     Environment.GetEnvironmentVariable("SIGNALWIRE_SPACE")!
 );
 
-client.Fabric.AiAgents.Create(name: "Bot", prompt: new() { ["text"] = "You are helpful." });
-client.PhoneNumbers.Search(areaCode: "512");
-client.Calling.Dial(from: "+15559876543", to: "+15551234567", url: "https://example.com/handler");
+await client.Fabric.AiAgents.CreateAsync(new Dictionary<string, object?>
+{
+    ["name"]   = "Bot",
+    ["prompt"] = new Dictionary<string, object> { ["text"] = "You are helpful." },
+});
+await client.PhoneNumbers.SearchAsync(new Dictionary<string, string> { ["area_code"] = "512" });
+await client.Calling.DialAsync(new Dictionary<string, object?>
+{
+    ["command"] = "dial",
+    ["params"]  = new Dictionary<string, object>
+    {
+        ["from"] = "+15559876543",
+        ["to"]   = "+15551234567",
+        ["url"]  = "https://example.com/handler",
+    },
+});
 ```
 
 ## RELAY Client
@@ -133,8 +146,7 @@ var client = new Client(new Dictionary<string, string>
 client.OnCall(async (call, evt) =>
 {
     await call.AnswerAsync();
-    var action = await call.PlayAsync(media: new[] { new Dictionary<string, object>
-        { ["type"] = "tts", ["params"] = new Dictionary<string, object> { ["text"] = "Hello!" } } });
+    var action = call.PlayTts("Hello!");
     await action.WaitAsync();
     await call.HangupAsync();
 });

--- a/docs/cli_guide.md
+++ b/docs/cli_guide.md
@@ -88,7 +88,7 @@ curl -X POST -u signalwire:password \
 ```bash
 mkdir my-agent && cd my-agent
 dotnet new console
-dotnet add package SignalWire
+dotnet add package SignalWire.Sdk
 ```
 
 ### Minimal Program.cs

--- a/docs/cloud_functions_guide.md
+++ b/docs/cloud_functions_guide.md
@@ -30,14 +30,18 @@ func new --name AgentHandler --template "HttpTrigger"
 
 2. **Add the SignalWire SDK reference**:
 ```xml
-<PackageReference Include="SignalWire.Agents" Version="*" />
+<PackageReference Include="SignalWire.Sdk" Version="*" />
 ```
 
-3. **Create the function** (`AgentHandler.cs`):
+3. **Create the function** (`AgentHandler.cs`). The
+`SignalWire.Serverless.Adapter` static class bridges the platform request into
+the agent's `HandleRequest` and returns a platform response dictionary
+(`Adapter.HandleAzure(agent, request)`):
 ```csharp
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using SignalWire.Agent;
+using SignalWire.Serverless;
 
 public class AgentHandler
 {
@@ -57,10 +61,17 @@ public class AgentHandler
     }
 
     [Function("AgentHandler")]
-    public async Task<HttpResponseData> Run(
+    public Dictionary<string, object?> Run(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req)
     {
-        return await _agent.HandleServerlessRequestAsync(req);
+        // Build the request dictionary (method/url/headers/body) from req,
+        // then dispatch through the adapter.
+        var request = new Dictionary<string, object?>
+        {
+            ["method"] = req.Method,
+            ["url"]    = req.Url.ToString(),
+        };
+        return Adapter.HandleAzure(_agent, request);
     }
 }
 ```
@@ -109,31 +120,38 @@ https://username:password@{function-app-name}.azurewebsites.net/api/{function-na
 ```bash
 dotnet new lambda.EmptyFunction --name MyAgentLambda
 cd MyAgentLambda/src/MyAgentLambda
-dotnet add package SignalWire.Agents
-dotnet add package Amazon.Lambda.AspNetCoreServer
+dotnet add package SignalWire.Sdk
+dotnet add package Amazon.Lambda.Core
 ```
 
-2. **Create your handler** (`Function.cs`):
+2. **Create your handler** (`Function.cs`). The handler receives the API
+Gateway event dictionary and passes it (with the agent) to
+`Adapter.HandleLambda`, which returns the API Gateway response
+(`statusCode`/`headers`/`body`):
 ```csharp
-using Amazon.Lambda.AspNetCoreServer;
+using Amazon.Lambda.Core;
 using SignalWire.Agent;
+using SignalWire.Serverless;
 
-public class LambdaFunction : APIGatewayProxyFunction
+public class LambdaFunction
 {
-    protected override void Init(IWebHostBuilder builder)
+    private readonly AgentBase _agent;
+
+    public LambdaFunction()
     {
-        var agent = new AgentBase(new AgentOptions
+        _agent = new AgentBase(new AgentOptions
         {
             Name  = "lambda-agent",
             Route = "/",
         });
 
-        agent.PromptAddSection("Role", "You are a helpful assistant running on AWS Lambda.");
-        agent.AddLanguage("English", "en-US", "inworld.Mark");
-        agent.SetParams(new Dictionary<string, object> { ["ai_model"] = "gpt-4.1-nano" });
-
-        builder.Configure(app => agent.ConfigureLambda(app));
+        _agent.PromptAddSection("Role", "You are a helpful assistant running on AWS Lambda.");
+        _agent.AddLanguage("English", "en-US", "inworld.Mark");
+        _agent.SetParams(new Dictionary<string, object> { ["ai_model"] = "gpt-4.1-nano" });
     }
+
+    public Dictionary<string, object?> Handler(Dictionary<string, object?> apiGatewayEvent)
+        => Adapter.HandleLambda(_agent, apiGatewayEvent);
 }
 ```
 
@@ -160,11 +178,14 @@ export SWML_BASIC_AUTH_PASSWORD="w00t"
 ```bash
 dotnet new web -n MyAgentFunction
 cd MyAgentFunction
-dotnet add package SignalWire.Agents
+dotnet add package SignalWire.Sdk
 dotnet add package Google.Cloud.Functions.Hosting
 ```
 
-2. **Create your function** (`Function.cs`):
+2. **Create your function** (`Function.cs`). Google Cloud Functions has no
+dedicated adapter entry point; dispatch the request straight to the agent's
+`HandleRequest(method, path, headers, body)`, which returns a
+`(Status, Headers, Body)` tuple:
 ```csharp
 using Google.Cloud.Functions.Framework;
 using Microsoft.AspNetCore.Http;
@@ -189,7 +210,17 @@ public class AgentFunction : IHttpFunction
 
     public async Task HandleAsync(HttpContext context)
     {
-        await _agent.HandleServerlessRequestAsync(context);
+        using var reader = new StreamReader(context.Request.Body);
+        var body = await reader.ReadToEndAsync();
+        var headers = context.Request.Headers
+            .ToDictionary(h => h.Key, h => h.Value.ToString());
+
+        var (status, respHeaders, respBody) =
+            _agent.HandleRequest(context.Request.Method, context.Request.Path, headers, body);
+
+        context.Response.StatusCode = status;
+        foreach (var kvp in respHeaders) context.Response.Headers[kvp.Key] = kvp.Value;
+        await context.Response.WriteAsync(respBody);
     }
 }
 ```
@@ -287,8 +318,10 @@ curl -u username:password \
 
 **Environment Detection:**
 ```csharp
-// Check detected mode
-var mode = ExecutionMode.Detect();
+using SignalWire.Serverless;
+
+// Check detected mode: "lambda", "gcf", "azure", "cgi", or "server"
+var mode = Adapter.Detect();
 Console.WriteLine($"Detected mode: {mode}");
 ```
 

--- a/docs/mcp_gateway_reference.md
+++ b/docs/mcp_gateway_reference.md
@@ -9,7 +9,7 @@ The MCP-SWAIG Gateway bridges Model Context Protocol (MCP) servers with SignalWi
 The MCP Gateway skill is included in the SignalWire Agents SDK:
 
 ```bash
-dotnet add package SignalWire.Agents
+dotnet add package SignalWire.Sdk
 ```
 
 The gateway server itself is a standalone service. Install with:

--- a/docs/sdk_features.md
+++ b/docs/sdk_features.md
@@ -64,7 +64,7 @@ Real-time call control and messaging over WebSocket using the Blade protocol (JS
 - Auto-reconnect with exponential backoff
 - All calling methods: play, record, collect, connect, detect, fax, tap, stream, AI, conferencing, queues
 - SMS/MMS messaging: send outbound, receive inbound, track delivery state
-- Action objects with `WaitAsync()`, `StopAsync()`, `PauseAsync()`, `ResumeAsync()`
+- Action objects with async `WaitAsync()` plus synchronous `Stop()`, `Pause()`, `Resume()`
 - Typed event classes for all call events
 - Dynamic context subscription/unsubscription
 
@@ -81,7 +81,7 @@ var client = new Client(new Dictionary<string, string>
 client.OnCall(async (call, evt) =>
 {
     await call.AnswerAsync();
-    var action = await call.PlayAsync(media: ttsMedia("Hello!"));
+    var action = call.PlayTts("Hello!");
     await action.WaitAsync();
     await call.HangupAsync();
 });
@@ -116,13 +116,26 @@ HTTP client for all SignalWire APIs. Lazily initializes namespace sub-objects.
 var client = new RestClient(projectId: id, token: tok, space: sp);
 
 // Fabric API
-client.Fabric.AiAgents.Create(name: "Bot", prompt: new() { ["text"] = "Hello" });
+await client.Fabric.AiAgents.CreateAsync(new Dictionary<string, object?>
+{
+    ["name"]   = "Bot",
+    ["prompt"] = new Dictionary<string, object> { ["text"] = "Hello" },
+});
 
 // Phone numbers
-var numbers = client.PhoneNumbers.List();
+var numbers = await client.PhoneNumbers.ListAsync();
 
 // Calling
-client.Calling.Dial(from: "+15559876543", to: "+15551234567", url: "https://example.com/handler");
+await client.Calling.DialAsync(new Dictionary<string, object?>
+{
+    ["command"] = "dial",
+    ["params"]  = new Dictionary<string, object>
+    {
+        ["from"] = "+15559876543",
+        ["to"]   = "+15551234567",
+        ["url"]  = "https://example.com/handler",
+    },
+});
 ```
 
 ## .NET-Specific Features

--- a/docs/web_service.md
+++ b/docs/web_service.md
@@ -36,7 +36,7 @@ WebService is designed to serve static files with configurable security features
 WebService is included in the core SignalWire AI Agents SDK:
 
 ```bash
-dotnet add package SignalWire.Agents
+dotnet add package SignalWire.Sdk
 ```
 
 ## Quick Start

--- a/examples/RelayAnswerAndWelcome.cs
+++ b/examples/RelayAnswerAndWelcome.cs
@@ -26,27 +26,11 @@ client.OnCall(async (call, evt) =>
     await call.AnswerAsync();
 
     // Play a welcome message
-    var action = await call.PlayAsync(media: new[]
-    {
-        new Dictionary<string, object>
-        {
-            ["type"]   = "tts",
-            ["params"] = new Dictionary<string, object>
-                { ["text"] = "Hello! This is a demo of the RELAY client in .NET." },
-        },
-    });
+    var action = call.PlayTts("Hello! This is a demo of the RELAY client in .NET.");
     await action.WaitAsync();
 
     // Say goodbye
-    var bye = await call.PlayAsync(media: new[]
-    {
-        new Dictionary<string, object>
-        {
-            ["type"]   = "tts",
-            ["params"] = new Dictionary<string, object>
-                { ["text"] = "Thank you for testing. Goodbye!" },
-        },
-    });
+    var bye = call.PlayTts("Thank you for testing. Goodbye!");
     await bye.WaitAsync();
 
     await call.HangupAsync();

--- a/relay/docs/call-methods.md
+++ b/relay/docs/call-methods.md
@@ -2,7 +2,11 @@
 
 ## Overview
 
-The `Call` object represents a live phone call. It provides async methods for every calling operation.
+The `Call` object represents a live phone call. Simple operations
+(answer, hangup, transfer, send digits, ...) are `async` methods returning a
+`Task`. Media operations (play, record, collect, detect, tap, ...) are
+**synchronous** methods that return an `*Action` handle; you `await` the
+handle's `WaitAsync()` to block until the operation completes.
 
 ## Answer and Hangup
 
@@ -14,46 +18,43 @@ await call.HangupAsync(reason: "busy");
 
 ## Play
 
-Play audio or TTS to the call.
+Play audio or TTS to the call. The typed convenience methods
+(`PlayTts`, `PlayAudio`, `PlaySilence`, `PlayRingtone`) build the media
+shape for you; the generic `Play(extra)` takes a raw RELAY payload. All
+return a `PlayAction` synchronously.
 
 ```csharp
 // TTS
-var action = await call.PlayAsync(media: new[]
-{
-    new Dictionary<string, object>
-    {
-        ["type"]   = "tts",
-        ["params"] = new Dictionary<string, object> { ["text"] = "Hello!" },
-    },
-});
+var action = call.PlayTts("Hello!");
 await action.WaitAsync();
 
 // Audio file
-var action = await call.PlayAsync(media: new[]
+var action = call.PlayAudio("https://example.com/audio.mp3");
+await action.WaitAsync();
+
+// Silence (seconds)
+var action = call.PlaySilence(2);
+await action.WaitAsync();
+
+// Raw payload via the generic Play(extra)
+var action = call.Play(new Dictionary<string, object?>
 {
-    new Dictionary<string, object>
+    ["play"] = new[]
     {
-        ["type"]   = "audio",
-        ["params"] = new Dictionary<string, object> { ["url"] = "https://example.com/audio.mp3" },
+        new Dictionary<string, object>
+        {
+            ["type"]   = "tts",
+            ["params"] = new Dictionary<string, object> { ["text"] = "Hello!" },
+        },
     },
 });
 await action.WaitAsync();
-
-// Silence
-var action = await call.PlayAsync(media: new[]
-{
-    new Dictionary<string, object>
-    {
-        ["type"]   = "silence",
-        ["params"] = new Dictionary<string, object> { ["duration"] = 2 },
-    },
-});
 ```
 
 ## Record
 
 ```csharp
-var action = await call.RecordAsync(new Dictionary<string, object>
+var action = call.Record(new Dictionary<string, object?>
 {
     ["beep"]        = true,
     ["format"]      = "wav",
@@ -62,15 +63,16 @@ var action = await call.RecordAsync(new Dictionary<string, object>
     ["end_silence"] = 5,
 });
 
-var result = await action.WaitAsync();
-// result contains recording URL
+await action.WaitAsync();
+// action.Url contains the recording URL once finished
 ```
 
 ## Play and Collect (DTMF/Speech)
 
 ```csharp
-var action = await call.PlayAndCollectAsync(
-    media: new[]
+var action = call.PlayAndCollect(new Dictionary<string, object?>
+{
+    ["play"] = new[]
     {
         new Dictionary<string, object>
         {
@@ -78,7 +80,7 @@ var action = await call.PlayAndCollectAsync(
             ["params"] = new Dictionary<string, object> { ["text"] = "Press 1 for sales, 2 for support." },
         },
     },
-    collect: new Dictionary<string, object>
+    ["collect"] = new Dictionary<string, object>
     {
         ["digits"] = new Dictionary<string, object>
         {
@@ -86,8 +88,8 @@ var action = await call.PlayAndCollectAsync(
             ["digit_timeout"] = 5.0,
         },
         ["initial_timeout"] = 10.0,
-    }
-);
+    },
+});
 
 var result = await action.WaitAsync();
 ```
@@ -97,8 +99,9 @@ var result = await action.WaitAsync();
 Bridge the call to another destination.
 
 ```csharp
-await call.ConnectAsync(
-    devices: new List<List<Dictionary<string, object>>>
+await call.ConnectAsync(new Dictionary<string, object?>
+{
+    ["devices"] = new List<List<Dictionary<string, object>>>
     {
         new()
         {
@@ -114,15 +117,15 @@ await call.ConnectAsync(
             },
         },
     },
-    ringback: new[]
+    ["ringback"] = new[]
     {
         new Dictionary<string, object>
         {
             ["type"]   = "tts",
             ["params"] = new Dictionary<string, object> { ["text"] = "Please wait." },
         },
-    }
-);
+    },
+});
 ```
 
 ## Detect
@@ -130,7 +133,7 @@ await call.ConnectAsync(
 Run detection on the call (machine, fax, digit).
 
 ```csharp
-var action = await call.DetectAsync(new Dictionary<string, object>
+var action = call.Detect(new Dictionary<string, object?>
 {
     ["type"]   = "machine",
     ["params"] = new Dictionary<string, object>
@@ -148,7 +151,7 @@ var result = await action.WaitAsync();
 Start a media tap (real-time audio stream).
 
 ```csharp
-var action = await call.TapAsync(new Dictionary<string, object>
+var action = call.Tap(new Dictionary<string, object?>
 {
     ["type"]   = "audio",
     ["params"] = new Dictionary<string, object>
@@ -167,21 +170,23 @@ var action = await call.TapAsync(new Dictionary<string, object>
 ## Send Digits
 
 ```csharp
-await call.SendDigitsAsync("1234#");
+await call.SendDigitsAsync(new Dictionary<string, object?> { ["digits"] = "1234#" });
 ```
 
 ## Action Control
 
-Actions returned by Play, Record, Detect, etc. support:
+Actions returned by Play, Record, Detect, etc. support a single async method,
+`WaitAsync()`; stop/pause/resume are synchronous (they fire-and-return a
+sub-command RPC). Pause/Resume exist only on `PlayAction` and `RecordAction`.
 
 ```csharp
-var action = await call.PlayAsync(media: ttsMedia);
+var action = call.PlayTts("Hello!");
 
-await action.WaitAsync();        // Wait for completion
+await action.WaitAsync();        // Wait for completion (default 30s)
 await action.WaitAsync(15);      // Wait with timeout (seconds)
-await action.StopAsync();        // Stop the action
-await action.PauseAsync();       // Pause (play only)
-await action.ResumeAsync();      // Resume (play only)
+action.Stop();                   // Stop the action
+action.Pause();                  // Pause (PlayAction / RecordAction)
+action.Resume();                 // Resume (PlayAction / RecordAction)
 ```
 
 ## Call Properties

--- a/relay/docs/client-reference.md
+++ b/relay/docs/client-reference.md
@@ -28,9 +28,8 @@ var client = new Client(new Dictionary<string, string>
 | `Project` | `string` | Project ID |
 | `Token` | `string` | API token |
 | `Host` | `string` | Server hostname |
-| `Contexts` | `List<string>` | Subscribed contexts |
+| `Contexts` | `IReadOnlyList<string>` | Subscribed contexts |
 | `Connected` | `bool` | Connection state |
-| `SessionId` | `string?` | Server-assigned session ID |
 | `Protocol` | `string?` | Negotiated protocol string |
 | `AuthorizationState` | `string?` | Current auth state |
 
@@ -142,12 +141,13 @@ var message = await client.SendMessageAsync(new Dictionary<string, object?>
 
 ### OnMessage()
 
-Register a handler for inbound messages.
+Register a handler for inbound messages. The callback receives the
+`Message` object and the `Event`.
 
 ```csharp
-client.OnMessage(async (evt, parms) =>
+client.OnMessage(async (message, evt) =>
 {
-    Console.WriteLine($"Message: {parms["body"]}");
+    Console.WriteLine($"Message: {message.Body}");
 });
 ```
 

--- a/relay/docs/events.md
+++ b/relay/docs/events.md
@@ -72,11 +72,13 @@ client.OnCall(async (call, evt) =>
 
 ### Message Handler
 
+The callback receives the `Message` object and the `Event`:
+
 ```csharp
-client.OnMessage(async (evt, parms) =>
+client.OnMessage(async (message, evt) =>
 {
-    var from = parms.GetValueOrDefault("from")?.ToString() ?? "unknown";
-    var body = parms.GetValueOrDefault("body")?.ToString() ?? "";
+    var from = message.FromNumber ?? "unknown";
+    var body = message.Body ?? "";
     Console.WriteLine($"Message from {from}: {body}");
 });
 ```

--- a/relay/docs/getting-started.md
+++ b/relay/docs/getting-started.md
@@ -5,7 +5,7 @@
 Add the SignalWire package to your project:
 
 ```bash
-dotnet add package SignalWire
+dotnet add package SignalWire.Sdk
 ```
 
 ## Environment Setup
@@ -34,14 +34,9 @@ client.OnCall(async (call, evt) =>
     Console.WriteLine($"Incoming call: {call.CallId}");
     await call.AnswerAsync();
 
-    var action = await call.PlayAsync(media: new[]
-    {
-        new Dictionary<string, object>
-        {
-            ["type"]   = "tts",
-            ["params"] = new Dictionary<string, object> { ["text"] = "Hello from SignalWire!" },
-        },
-    });
+    // Play* methods are synchronous and return an *Action handle.
+    // Await the handle's WaitAsync() to block until playback finishes.
+    var action = call.PlayTts("Hello from SignalWire!");
     await action.WaitAsync();
 
     await call.HangupAsync();

--- a/relay/docs/messaging.md
+++ b/relay/docs/messaging.md
@@ -35,13 +35,15 @@ var message = await client.SendMessageAsync(new Dictionary<string, object?>
 
 Register a message handler to receive inbound messages:
 
+The callback receives the `Message` object and the `Event`:
+
 ```csharp
-client.OnMessage(async (evt, parms) =>
+client.OnMessage(async (message, evt) =>
 {
-    var from    = parms.GetValueOrDefault("from")?.ToString() ?? "unknown";
-    var to      = parms.GetValueOrDefault("to")?.ToString() ?? "unknown";
-    var body    = parms.GetValueOrDefault("body")?.ToString() ?? "";
-    var context = parms.GetValueOrDefault("context")?.ToString() ?? "";
+    var from    = message.FromNumber ?? "unknown";
+    var to      = message.ToNumber ?? "unknown";
+    var body    = message.Body ?? "";
+    var context = message.Context ?? "";
 
     Console.WriteLine($"Inbound message from {from} to {to}: {body}");
 

--- a/rest/docs/calling.md
+++ b/rest/docs/calling.md
@@ -2,40 +2,54 @@
 
 ## Overview
 
-The Calling namespace provides REST-based call control with 37 commands. These methods control live calls without requiring a WebSocket connection.
+The Calling namespace provides REST-based call control with 37 commands. These
+methods control live calls without requiring a WebSocket connection. Every
+command is asynchronous and returns `Task<Dictionary<string, object?>>`; the
+per-call commands take the `callId` first and the RELAY-style payload as a
+`Dictionary<string, object?>`.
 
 ## Dial
 
+`DialAsync` takes a single payload `Dictionary`:
+
 ```csharp
-client.Calling.Dial(
-    from: "+15559876543",
-    to:   "+15551234567",
-    url:  "https://example.com/call-handler"
-);
+await client.Calling.DialAsync(new Dictionary<string, object?>
+{
+    ["command"] = "dial",
+    ["params"]  = new Dictionary<string, object>
+    {
+        ["from"] = "+15559876543",
+        ["to"]   = "+15551234567",
+        ["url"]  = "https://example.com/call-handler",
+    },
+});
 ```
 
 ## Play
 
 ```csharp
 // TTS
-client.Calling.Play(callId, new Dictionary<string, object>
+await client.Calling.PlayAsync(callId, new Dictionary<string, object?>
 {
     ["type"]   = "tts",
     ["params"] = new Dictionary<string, object> { ["text"] = "Hello!" },
 });
 
 // Audio file
-client.Calling.Play(callId, new Dictionary<string, object>
+await client.Calling.PlayAsync(callId, new Dictionary<string, object?>
 {
     ["type"]   = "audio",
     ["params"] = new Dictionary<string, object> { ["url"] = "https://example.com/audio.mp3" },
 });
 ```
 
+Playback control: `PlayPauseAsync`, `PlayResumeAsync`, `PlayStopAsync`,
+`PlayVolumeAsync` (each takes `callId` + optional payload).
+
 ## Record
 
 ```csharp
-client.Calling.Record(callId, new Dictionary<string, object>
+await client.Calling.RecordAsync(callId, new Dictionary<string, object?>
 {
     ["beep"]      = true,
     ["format"]    = "wav",
@@ -43,10 +57,12 @@ client.Calling.Record(callId, new Dictionary<string, object>
 });
 ```
 
+Record control: `RecordPauseAsync`, `RecordResumeAsync`, `RecordStopAsync`.
+
 ## Collect
 
 ```csharp
-client.Calling.Collect(callId, new Dictionary<string, object>
+await client.Calling.CollectAsync(callId, new Dictionary<string, object?>
 {
     ["digits"] = new Dictionary<string, object>
     {
@@ -56,33 +72,10 @@ client.Calling.Collect(callId, new Dictionary<string, object>
 });
 ```
 
-## Connect
-
-```csharp
-client.Calling.Connect(callId, new Dictionary<string, object>
-{
-    ["devices"] = new List<List<Dictionary<string, object>>>
-    {
-        new()
-        {
-            new Dictionary<string, object>
-            {
-                ["type"]   = "phone",
-                ["params"] = new Dictionary<string, object>
-                {
-                    ["to_number"]   = "+15551234567",
-                    ["from_number"] = "+15559876543",
-                },
-            },
-        },
-    },
-});
-```
-
 ## Detect
 
 ```csharp
-client.Calling.Detect(callId, new Dictionary<string, object>
+await client.Calling.DetectAsync(callId, new Dictionary<string, object?>
 {
     ["type"]   = "machine",
     ["params"] = new Dictionary<string, object>
@@ -96,7 +89,7 @@ client.Calling.Detect(callId, new Dictionary<string, object>
 ## Tap
 
 ```csharp
-client.Calling.Tap(callId, new Dictionary<string, object>
+await client.Calling.TapAsync(callId, new Dictionary<string, object?>
 {
     ["type"]   = "audio",
     ["params"] = new Dictionary<string, object>
@@ -110,7 +103,7 @@ client.Calling.Tap(callId, new Dictionary<string, object>
 ## Stream
 
 ```csharp
-client.Calling.Stream(callId, new Dictionary<string, object>
+await client.Calling.StreamAsync(callId, new Dictionary<string, object?>
 {
     ["url"]       = "wss://listener.example.com/stream",
     ["direction"] = "both",
@@ -120,71 +113,52 @@ client.Calling.Stream(callId, new Dictionary<string, object>
 
 ## AI
 
+The AI commands are `AiMessageAsync`, `AiHoldAsync`, `AiUnholdAsync`, and
+`AiStopAsync`:
+
 ```csharp
-client.Calling.Ai(callId, new Dictionary<string, object>
+await client.Calling.AiMessageAsync(callId, new Dictionary<string, object?>
 {
-    ["prompt"] = new Dictionary<string, object> { ["text"] = "You are helpful." },
-    ["SWAIG"]  = new Dictionary<string, object>
-    {
-        ["functions"] = new List<Dictionary<string, object>>
-        {
-            new()
-            {
-                ["function"]     = "get_info",
-                ["purpose"]      = "Get information",
-                ["web_hook_url"] = "https://example.com/swaig",
-            },
-        },
-    },
+    ["role"]    = "user",
+    ["message"] = "Please summarize the call.",
 });
 ```
 
 ## Transcribe
 
 ```csharp
-client.Calling.Transcribe(callId, new Dictionary<string, object>
+await client.Calling.TranscribeAsync(callId, new Dictionary<string, object?>
 {
     ["language"]  = "en-US",
     ["direction"] = "both",
 });
 ```
 
+Live variants: `LiveTranscribeAsync`, `LiveTranslateAsync`.
+
 ## Denoise
 
 ```csharp
-client.Calling.Denoise(callId, new Dictionary<string, object>());
+await client.Calling.DenoiseAsync(callId);
+await client.Calling.DenoiseStopAsync(callId);
 ```
 
-## Answer / Hangup
+## End and Transfer
 
 ```csharp
-client.Calling.Answer(callId);
-client.Calling.Hangup(callId);
-```
-
-## Send Digits
-
-```csharp
-client.Calling.SendDigits(callId, "1234#");
-```
-
-## Queue
-
-```csharp
-client.Calling.Enqueue(callId, new Dictionary<string, object>
+await client.Calling.EndAsync(callId);
+await client.Calling.TransferAsync(callId, new Dictionary<string, object?>
 {
-    ["queue_name"] = "support",
-    ["max_wait"]   = 300,
+    ["dest"] = "+15551234567",
 });
+await client.Calling.DisconnectAsync(callId);
 ```
 
-## Conference
+## Refer
 
 ```csharp
-client.Calling.Conference(callId, new Dictionary<string, object>
+await client.Calling.ReferAsync(callId, new Dictionary<string, object?>
 {
-    ["name"]  = "team-meeting",
-    ["beep"]  = true,
-    ["muted"] = false,
+    ["to_uri"] = "sip:agent@example.com",
 });
 ```

--- a/rest/docs/client-reference.md
+++ b/rest/docs/client-reference.md
@@ -58,30 +58,31 @@ All namespace accessors are lazily initialized on first access.
 
 ## CrudResource Methods
 
-All `CrudResource` instances support:
+All `CrudResource` instances expose asynchronous methods returning
+`Task<Dictionary<string, object?>>`:
 
 | Method | Description |
 |--------|-------------|
-| `List()` | List all resources |
-| `Get(id)` | Get a single resource |
-| `Create(data)` | Create a new resource |
-| `Update(id, data)` | Update a resource |
-| `Delete(id)` | Delete a resource |
-| `Search(...)` | Search (where supported) |
+| `ListAsync(queryParams?)` | List resources (`Dictionary<string, string>` query params) |
+| `GetAsync(id)` | Get a single resource |
+| `CreateAsync(data)` | Create a new resource (`Dictionary<string, object?>` body) |
+| `UpdateAsync(id, data)` | Update a resource |
+| `DeleteAsync(id)` | Delete a resource |
+| `SearchAsync(...)` | Search (where supported) |
 
 ## Error Handling
 
 ```csharp
 try
 {
-    var result = client.PhoneNumbers.List();
+    var result = await client.PhoneNumbers.ListAsync();
 }
 catch (ArgumentException ex)
 {
-    // Missing or invalid credentials
+    // Missing or invalid credentials (thrown by the RestClient constructor)
     Console.WriteLine($"Config error: {ex.Message}");
 }
-catch (Exception ex)
+catch (SignalWireRestError ex)
 {
     // HTTP or API error
     Console.WriteLine($"REST error: {ex.Message}");
@@ -94,8 +95,8 @@ The underlying `HttpClient` handles authentication, JSON serialization, and erro
 
 ```csharp
 // Direct HTTP access for custom endpoints
-var response = client.Http.Get("/api/custom/endpoint");
-var result = client.Http.Post("/api/custom/endpoint", new Dictionary<string, object>
+var response = await client.Http.GetAsync("/api/custom/endpoint");
+var result = await client.Http.PostAsync("/api/custom/endpoint", new Dictionary<string, object?>
 {
     ["key"] = "value",
 });

--- a/rest/docs/compat.md
+++ b/rest/docs/compat.md
@@ -6,8 +6,12 @@ The Compatibility API provides a Twilio-compatible LAML (LaML) surface for migra
 
 ## Making Calls
 
+`Compat` is a container of LaML sub-resources (`Calls`, `Messages`, `Faxes`,
+`Conferences`, ...), each exposing the async CRUD methods. Calls are created on
+`Compat.Calls`:
+
 ```csharp
-var call = client.Compat.Create(new Dictionary<string, object>
+var call = await client.Compat.Calls.CreateAsync(new Dictionary<string, object?>
 {
     ["To"]   = "+15551234567",
     ["From"] = "+15559876543",
@@ -19,7 +23,7 @@ Console.WriteLine($"Call SID: {call["sid"]}");
 ## Sending SMS
 
 ```csharp
-var message = client.Compat.Create(new Dictionary<string, object>
+var message = await client.Compat.Messages.CreateAsync(new Dictionary<string, object?>
 {
     ["To"]   = "+15551234567",
     ["From"] = "+15559876543",
@@ -62,7 +66,7 @@ var client = new RestClient(
 
 ```csharp
 // Same LAML URLs work with SignalWire
-client.Compat.Create(new Dictionary<string, object>
+await client.Compat.Calls.CreateAsync(new Dictionary<string, object?>
 {
     ["To"]   = "+15551234567",
     ["From"] = "+15559876543",
@@ -83,10 +87,11 @@ client.Compat.Create(new Dictionary<string, object>
 
 ```csharp
 // List calls
-var calls = client.Compat.List();
+var calls = await client.Compat.Calls.ListAsync();
 
-// List with filters (append to path)
-var filtered = client.Compat.Http.Get(
-    $"/api/laml/2010-04-01/Accounts/{client.ProjectId}/Calls.json?Status=completed"
-);
+// List with filters (query-param Dictionary)
+var filtered = await client.Compat.Calls.ListAsync(new Dictionary<string, string>
+{
+    ["Status"] = "completed",
+});
 ```

--- a/rest/docs/fabric.md
+++ b/rest/docs/fabric.md
@@ -2,39 +2,40 @@
 
 ## Overview
 
-The Fabric namespace manages AI agents, SWML scripts, subscribers, call flows, SIP endpoints, cXML resources, and more. Each sub-resource supports standard CRUD operations.
+The Fabric namespace manages AI agents, SWML scripts, subscribers, call flows, SIP endpoints, cXML resources, and more. Each sub-resource exposes the async CRUD methods (`ListAsync`/`GetAsync`/`CreateAsync`/`UpdateAsync`/`DeleteAsync`).
 
 ## AI Agents
 
 ```csharp
 // Create
-var agent = client.Fabric.AiAgents.Create(
-    name:   "Support Bot",
-    prompt: new Dictionary<string, object> { ["text"] = "You are a helpful support agent." }
-);
+var agent = await client.Fabric.AiAgents.CreateAsync(new Dictionary<string, object?>
+{
+    ["name"]   = "Support Bot",
+    ["prompt"] = new Dictionary<string, object> { ["text"] = "You are a helpful support agent." },
+});
 var agentId = agent["id"].ToString();
 
 // List
-var agents = client.Fabric.AiAgents.List();
+var agents = await client.Fabric.AiAgents.ListAsync();
 
 // Get
-var details = client.Fabric.AiAgents.Get(agentId);
+var details = await client.Fabric.AiAgents.GetAsync(agentId);
 
 // Update
-client.Fabric.AiAgents.Update(agentId, new Dictionary<string, object>
+await client.Fabric.AiAgents.UpdateAsync(agentId, new Dictionary<string, object?>
 {
     ["name"] = "Updated Bot",
 });
 
 // Delete
-client.Fabric.AiAgents.Delete(agentId);
+await client.Fabric.AiAgents.DeleteAsync(agentId);
 ```
 
 ## SWML Scripts
 
 ```csharp
 // Create
-var script = client.Fabric.SwmlScripts.Create(new Dictionary<string, object>
+var script = await client.Fabric.SwmlScripts.CreateAsync(new Dictionary<string, object?>
 {
     ["name"]    = "greeting",
     ["content"] = new Dictionary<string, object>
@@ -53,14 +54,14 @@ var script = client.Fabric.SwmlScripts.Create(new Dictionary<string, object>
 });
 
 // List
-var scripts = client.Fabric.SwmlScripts.List();
+var scripts = await client.Fabric.SwmlScripts.ListAsync();
 ```
 
 ## Subscribers
 
 ```csharp
 // Create a SIP subscriber
-var subscriber = client.Fabric.Subscribers.Create(new Dictionary<string, object>
+var subscriber = await client.Fabric.Subscribers.CreateAsync(new Dictionary<string, object?>
 {
     ["display_name"] = "Alice Smith",
     ["type"]         = "sip",
@@ -69,14 +70,14 @@ var subscriber = client.Fabric.Subscribers.Create(new Dictionary<string, object>
 });
 
 // List
-var subscribers = client.Fabric.Subscribers.List();
+var subscribers = await client.Fabric.Subscribers.ListAsync();
 ```
 
 ## Call Flows
 
 ```csharp
 // Create
-var flow = client.Fabric.CallFlows.Create(new Dictionary<string, object>
+var flow = await client.Fabric.CallFlows.CreateAsync(new Dictionary<string, object?>
 {
     ["name"]    = "main-ivr",
     ["content"] = new Dictionary<string, object>
@@ -98,14 +99,14 @@ var flow = client.Fabric.CallFlows.Create(new Dictionary<string, object>
 });
 
 // List
-var flows = client.Fabric.CallFlows.List();
+var flows = await client.Fabric.CallFlows.ListAsync();
 ```
 
 ## SIP Endpoints
 
 ```csharp
 // Create
-var endpoint = client.Fabric.SipEndpoints.Create(new Dictionary<string, object>
+var endpoint = await client.Fabric.SipEndpoints.CreateAsync(new Dictionary<string, object?>
 {
     ["username"]     = "alice",
     ["password"]     = "secure-password",
@@ -114,13 +115,16 @@ var endpoint = client.Fabric.SipEndpoints.Create(new Dictionary<string, object>
 });
 
 // List
-var endpoints = client.Fabric.SipEndpoints.List();
+var endpoints = await client.Fabric.SipEndpoints.ListAsync();
 ```
 
 ## cXML Resources
 
+cXML is exposed as `CxmlScripts` (inline scripts), `CxmlApplications`, and
+`CxmlWebhooks`:
+
 ```csharp
-var cxml = client.Fabric.CxmlResources.Create(new Dictionary<string, object>
+var cxml = await client.Fabric.CxmlScripts.CreateAsync(new Dictionary<string, object?>
 {
     ["name"] = "conference-handler",
     ["body"] = "<Response><Dial><Conference>room-1</Conference></Dial></Response>",
@@ -134,9 +138,9 @@ and lists its addresses (there is no generic create — create a typed resource,
 e.g. ``SwmlScripts``/``CallFlows``):
 
 ```csharp
-var resources = client.Fabric.ResourcesGeneric.List();
-var resource  = client.Fabric.ResourcesGeneric.Get(resourceId);
-var addrs     = client.Fabric.ResourcesGeneric.ListAddresses(resourceId);
+var resources = await client.Fabric.ResourcesGeneric.ListAsync();
+var resource  = await client.Fabric.ResourcesGeneric.GetAsync(resourceId);
+var addrs     = await client.Fabric.ResourcesGeneric.ListAddressesAsync(resourceId);
 ```
 
 ## Addresses
@@ -145,8 +149,8 @@ Top-level Fabric addresses are read-only (list/get); a resource's addresses are
 created by binding a phone number (the server auto-materializes them):
 
 ```csharp
-var addresses = client.Fabric.AddressesTopLevel.List();
-var address   = client.Fabric.AddressesTopLevel.Get(addressId);
+var addresses = await client.Fabric.AddressesTopLevel.ListAsync();
+var address   = await client.Fabric.AddressesTopLevel.GetAsync(addressId);
 ```
 
 ## Tokens
@@ -154,7 +158,7 @@ var address   = client.Fabric.AddressesTopLevel.Get(addressId);
 Generate authentication tokens for subscribers:
 
 ```csharp
-var token = client.Fabric.TokensApi.CreateSubscriberToken(new Dictionary<string, object>
+var token = await client.Fabric.TokensApi.CreateSubscriberTokenAsync(new Dictionary<string, object?>
 {
     ["subscriber_id"] = subscriberId,
     ["ttl"]           = 3600,

--- a/rest/docs/getting-started.md
+++ b/rest/docs/getting-started.md
@@ -3,7 +3,7 @@
 ## Installation
 
 ```bash
-dotnet add package SignalWire
+dotnet add package SignalWire.Sdk
 ```
 
 ## Environment Setup
@@ -26,11 +26,11 @@ var client = new RestClient(
 );
 
 // List phone numbers
-var numbers = client.PhoneNumbers.List();
+var numbers = await client.PhoneNumbers.ListAsync();
 Console.WriteLine($"Found {((numbers["data"] as List<object>)?.Count ?? 0)} numbers");
 
 // List AI agents
-var agents = client.Fabric.AiAgents.List();
+var agents = await client.Fabric.AiAgents.ListAsync();
 Console.WriteLine($"Found {((agents["data"] as List<object>)?.Count ?? 0)} agents");
 ```
 
@@ -53,10 +53,10 @@ var client = new RestClient();
 ```csharp
 try
 {
-    var result = client.PhoneNumbers.List();
+    var result = await client.PhoneNumbers.ListAsync();
     Console.WriteLine("Success");
 }
-catch (Exception ex)
+catch (SignalWireRestError ex)
 {
     Console.WriteLine($"REST error: {ex.Message}");
 }
@@ -66,27 +66,30 @@ catch (Exception ex)
 
 All namespace resources support standard CRUD:
 
+All CRUD methods are asynchronous and take a `Dictionary` body.
+
 ```csharp
-// List
-var items = client.PhoneNumbers.List();
+// List (optional query params as Dictionary<string, string>)
+var items = await client.PhoneNumbers.ListAsync();
 
 // Create
-var item = client.Fabric.AiAgents.Create(
-    name:   "Bot",
-    prompt: new Dictionary<string, object> { ["text"] = "You are helpful." }
-);
+var item = await client.Fabric.AiAgents.CreateAsync(new Dictionary<string, object?>
+{
+    ["name"]   = "Bot",
+    ["prompt"] = new Dictionary<string, object> { ["text"] = "You are helpful." },
+});
 
 // Read
-var agent = client.Fabric.AiAgents.Get(agentId);
+var agent = await client.Fabric.AiAgents.GetAsync(agentId);
 
 // Update
-client.Fabric.AiAgents.Update(agentId, new Dictionary<string, object>
+await client.Fabric.AiAgents.UpdateAsync(agentId, new Dictionary<string, object?>
 {
     ["name"] = "Updated Bot",
 });
 
 // Delete
-client.Fabric.AiAgents.Delete(agentId);
+await client.Fabric.AiAgents.DeleteAsync(agentId);
 ```
 
 ## Next Steps

--- a/rest/docs/namespaces.md
+++ b/rest/docs/namespaces.md
@@ -11,12 +11,16 @@ The `RestClient` exposes 21 lazily-initialized namespace accessors covering ever
 Full Fabric API with sub-resources for AI agents, SWML scripts, subscribers, call flows, and more.
 
 ```csharp
-client.Fabric.AiAgents.List();
-client.Fabric.AiAgents.Create(name: "Bot", prompt: promptDict);
-client.Fabric.SwmlScripts.List();
-client.Fabric.Subscribers.List();
-client.Fabric.CallFlows.List();
-client.Fabric.SipEndpoints.List();
+await client.Fabric.AiAgents.ListAsync();
+await client.Fabric.AiAgents.CreateAsync(new Dictionary<string, object?>
+{
+    ["name"]   = "Bot",
+    ["prompt"] = promptDict,
+});
+await client.Fabric.SwmlScripts.ListAsync();
+await client.Fabric.Subscribers.ListAsync();
+await client.Fabric.CallFlows.ListAsync();
+await client.Fabric.SipEndpoints.ListAsync();
 ```
 
 See [Fabric Resources](fabric.md) for details.
@@ -26,7 +30,16 @@ See [Fabric Resources](fabric.md) for details.
 REST-based call control with 37 commands.
 
 ```csharp
-client.Calling.Dial(from: "+15559876543", to: "+15551234567", url: "https://example.com/handler");
+await client.Calling.DialAsync(new Dictionary<string, object?>
+{
+    ["command"] = "dial",
+    ["params"]  = new Dictionary<string, object>
+    {
+        ["from"] = "+15559876543",
+        ["to"]   = "+15551234567",
+        ["url"]  = "https://example.com/handler",
+    },
+});
 ```
 
 See [Calling Commands](calling.md) for details.
@@ -36,11 +49,11 @@ See [Calling Commands](calling.md) for details.
 Phone number management.
 
 ```csharp
-client.PhoneNumbers.List();
-client.PhoneNumbers.Search(areaCode: "512");
-client.PhoneNumbers.Get(numberId);
-client.PhoneNumbers.Update(numberId, new Dictionary<string, object> { ["name"] = "Main Line" });
-client.PhoneNumbers.Delete(numberId);
+await client.PhoneNumbers.ListAsync();
+await client.PhoneNumbers.SearchAsync(new Dictionary<string, string> { ["area_code"] = "512" });
+await client.PhoneNumbers.GetAsync(numberId);
+await client.PhoneNumbers.UpdateAsync(numberId, new Dictionary<string, object?> { ["name"] = "Main Line" });
+await client.PhoneNumbers.DeleteAsync(numberId);
 ```
 
 ### Datasphere
@@ -48,10 +61,10 @@ client.PhoneNumbers.Delete(numberId);
 Document management and semantic search.
 
 ```csharp
-client.Datasphere.Documents.List();
-client.Datasphere.Documents.Create(new Dictionary<string, object> { ["url"] = "https://example.com/doc.pdf" });
-client.Datasphere.Documents.Get(docId);
-client.Datasphere.Documents.Delete(docId);
+await client.Datasphere.Documents.ListAsync();
+await client.Datasphere.Documents.CreateAsync(new Dictionary<string, object?> { ["url"] = "https://example.com/doc.pdf" });
+await client.Datasphere.Documents.GetAsync(docId);
+await client.Datasphere.Documents.DeleteAsync(docId);
 ```
 
 ### Video
@@ -59,10 +72,10 @@ client.Datasphere.Documents.Delete(docId);
 Video rooms, sessions, conferences.
 
 ```csharp
-client.Video.List();
-client.Video.Create(new Dictionary<string, object> { ["name"] = "meeting-room" });
-client.Video.Get(roomId);
-client.Video.Delete(roomId);
+await client.Video.ListAsync();
+await client.Video.CreateAsync(new Dictionary<string, object?> { ["name"] = "meeting-room" });
+await client.Video.GetAsync(roomId);
+await client.Video.DeleteAsync(roomId);
 ```
 
 ### Compat
@@ -70,8 +83,8 @@ client.Video.Delete(roomId);
 Twilio-compatible LAML API.
 
 ```csharp
-client.Compat.List();
-client.Compat.Create(new Dictionary<string, object>
+await client.Compat.Calls.ListAsync();
+await client.Compat.Calls.CreateAsync(new Dictionary<string, object?>
 {
     ["To"]   = "+15551234567",
     ["From"] = "+15559876543",
@@ -84,55 +97,57 @@ See [Compatibility API](compat.md) for details.
 ### Addresses
 
 ```csharp
-client.Addresses.List();
-client.Addresses.Create(new Dictionary<string, object> { ["type"] = "client", ["name"] = "WebClient" });
+await client.Addresses.ListAsync();
+await client.Addresses.CreateAsync(new Dictionary<string, object?> { ["type"] = "client", ["name"] = "WebClient" });
 ```
 
 ### Queues
 
 ```csharp
-client.Queues.List();
-client.Queues.Create(new Dictionary<string, object> { ["name"] = "support-queue" });
+await client.Queues.ListAsync();
+await client.Queues.CreateAsync(new Dictionary<string, object?> { ["name"] = "support-queue" });
 ```
 
 ### Recordings
 
 ```csharp
-client.Recordings.List();
-client.Recordings.Get(recordingId);
-client.Recordings.Delete(recordingId);
+await client.Recordings.ListAsync();
+await client.Recordings.GetAsync(recordingId);
+await client.Recordings.DeleteAsync(recordingId);
 ```
 
 ### NumberGroups
 
 ```csharp
-client.NumberGroups.List();
-client.NumberGroups.Create(new Dictionary<string, object> { ["name"] = "sales-numbers" });
+await client.NumberGroups.ListAsync();
+await client.NumberGroups.CreateAsync(new Dictionary<string, object?> { ["name"] = "sales-numbers" });
 ```
 
 ### VerifiedCallers
 
 ```csharp
-client.VerifiedCallers.List();
-client.VerifiedCallers.Create(new Dictionary<string, object> { ["phone_number"] = "+15551234567" });
+await client.VerifiedCallers.ListAsync();
+await client.VerifiedCallers.CreateAsync(new Dictionary<string, object?> { ["phone_number"] = "+15551234567" });
 ```
 
 ### SipProfile
 
+The SIP profile is a singleton (get/update, no list):
+
 ```csharp
-client.SipProfile.List();
+await client.SipProfile.GetAsync();
 ```
 
 ### Lookup
 
 ```csharp
-client.Lookup.Get("+15551234567");
+await client.Lookup.PhoneNumberAsync("+15551234567");
 ```
 
 ### ShortCodes
 
 ```csharp
-client.ShortCodes.List();
+await client.ShortCodes.ListAsync();
 ```
 
 ### ImportedNumbers
@@ -140,7 +155,7 @@ client.ShortCodes.List();
 Import an externally-hosted number (create-only).
 
 ```csharp
-client.ImportedNumbers.Create(new Dictionary<string, object> { ["number"] = "+15551234567" });
+await client.ImportedNumbers.CreateAsync(new Dictionary<string, object?> { ["number"] = "+15551234567" });
 ```
 
 ### Mfa
@@ -148,7 +163,7 @@ client.ImportedNumbers.Create(new Dictionary<string, object> { ["number"] = "+15
 Multi-factor authentication.
 
 ```csharp
-client.Mfa.Sms(new Dictionary<string, object>
+await client.Mfa.SmsAsync(new Dictionary<string, object?>
 {
     ["to"]      = "+15551234567",
     ["from"]    = "+15559876543",
@@ -158,31 +173,32 @@ client.Mfa.Sms(new Dictionary<string, object>
 
 ### Registry
 
-10DLC brands, campaigns, orders.
+10DLC brands, campaigns, orders. `Registry` is a container of beta
+sub-resources (`Brands`, `Campaigns`, `Orders`, `Numbers`):
 
 ```csharp
-client.Registry.List();
-client.Registry.Create(new Dictionary<string, object>
+await client.Registry.Brands.ListAsync();
+await client.Registry.Brands.CreateAsync(new Dictionary<string, object?>
 {
-    ["type"] = "brand",
     ["name"] = "Acme Corp",
 });
 ```
 
 ### Logs
 
-Message, voice, fax, conference logs.
+Message, voice, fax, conference logs. `Logs` is a container of per-API log
+sub-resources (`Messages`, `Voice`, `Fax`, `Conferences`):
 
 ```csharp
-client.Logs.List();
+await client.Logs.Messages.ListAsync();
 ```
 
 ### Project
 
-Project management.
+Project API tokens (the `Project` namespace exposes `Tokens` only):
 
 ```csharp
-client.Project.Get("self");
+await client.Project.Tokens.CreateAsync(new Dictionary<string, object?> { ["name"] = "ci-token" });
 ```
 
 ### Pubsub
@@ -190,7 +206,7 @@ client.Project.Get("self");
 PubSub tokens.
 
 ```csharp
-client.Pubsub.Create(new Dictionary<string, object> { ["channels"] = new List<string> { "updates" } });
+await client.Pubsub.CreateTokenAsync(new Dictionary<string, object?> { ["channels"] = new List<string> { "updates" } });
 ```
 
 ### Chat
@@ -198,5 +214,5 @@ client.Pubsub.Create(new Dictionary<string, object> { ["channels"] = new List<st
 Chat tokens.
 
 ```csharp
-client.Chat.Create(new Dictionary<string, object> { ["member_id"] = "user-123" });
+await client.Chat.CreateTokenAsync(new Dictionary<string, object?> { ["member_id"] = "user-123" });
 ```


### PR DESCRIPTION
## Summary

Content/consistency audit of the .NET README against the Python reference structure (`signalwire-python/README.md`) and the **actual current SDK surface in `src/`**. The .NET README was the shortest of all ports and was missing whole sections; it also contained several code examples that referenced removed or never-implemented API.

This is documentation-only (no new gate — that is a separate future task).

## Findings (what was stale / missing / broken)

**Missing sections (vs Python):**
- No `Agent Examples` table.
- No `Documentation` section at all (Getting Started / Core Features / Skills and Extensions / Deployment / Reference).
- No `swaig-test` CLI usage, despite `bin/swaig-test` existing.
- Env-var table omitted the SSL vars even though `SWML_SSL_ENABLED`/`SWML_SSL_CERT_PATH`/`SWML_SSL_KEY_PATH` are read in `SWML/Service.cs`.

**Broken / phantom API in code examples:**
- **RELAY example** used `new RelayClient(new RelayOptions { ... })`, `new TtsMedia(...)`, `call.Answer()`, `call.Play(...)`, `call.Hangup()`, `client.Run()` — **none of these exist**. The real type is `SignalWire.Relay.Client` constructed from a `Dictionary<string,string>`, with `AnswerAsync()`, `PlayAsync(media: ...)`, `HangupAsync()`, and `ConnectAsync()` + `RunAsync()`.
- **REST example** used synchronous, named-argument calls (`Fabric.AiAgents.Create(new { name = ... })`, `Calling.Play(...)`, `PhoneNumbers.List(new { area_code })`, `Datasphere.Documents.Search(new { query_string })`). The real API is fully async, takes `Dictionary` arguments, and returns `Task<Dictionary<string,object?>>` (`CreateAsync`, `SearchAsync`, etc.).
- **Agent example** passed `new { }` for `DefineTool` parameters; the signature requires `Dictionary<string, object>`.
- **Action bullet** claimed `StopAsync()/PauseAsync()/ResumeAsync()`; the real methods are synchronous `Stop()/Pause()/Resume()` (only `WaitAsync()` is async).

**Accuracy / staleness:**
- Runtime claim was ".NET 8.0+"; the project targets `net8.0;net9.0;net10.0` — changed to "Targets .NET 8.0, 9.0, and 10.0".

## What I fixed

- Added `Agent Examples`, `Documentation`, and `swaig-test` CLI content; expanded `Testing`; added SSL env vars.
- Rewrote the RELAY, REST, and Agent code blocks to the real, current API.
- Corrected the runtime version claim and the Action-method bullet.

## Verified against `src/`

- Package id `SignalWire.Sdk` (Directory.Build.props), version 1.1.2.
- 21 namespaced REST surfaces on `RestClient` (table's "18+" holds; detail line "21" matches).
- 18 built-in skills (`Skills/Builtin/`, excluding `HttpHelper`), 5 prefabs.
- `AgentBase`/`AgentOptions`, `AddLanguage`, `PromptAddSection`, `DefineTool`, `AddSkill`, `FunctionResult`, `AgentServer`, and `swaig-test` all exist as shown.
- All relative links (docs/*.md, examples/*.cs, relay/README.md, rest/README.md, examples/README.md, LICENSE) resolve.

## Python-only sections deliberately omitted

- **Search System** (`.swsearch` build/index, PDF/DOCX/Excel processing) and the `search-*` install extras — the .NET port has **no local index-building system**. `NativeVectorSearchSkill` is **remote-query-only** (documented in `PORT_OMISSIONS.md`), so adding a Search System section would advertise a feature the port lacks.
- **Tutorials** section and **Bedrock** guide — no `tutorial/` directory and no `bedrock` doc exist in this port.

## DOC-AUDIT

`audit_docs.py` (the DOC-AUDIT gate) passes: `✓ docs/examples reference only known symbols (1027 resolved / 1979 total)`, exit 0. Note the gate's scanned dirs are `docs/`, `rest/docs`, `relay/docs`, `examples/` (not the repo-root README), so it neither regressed nor newly covers the README; I separately verified every symbol introduced in the README resolves to a real entry in `port_surface.json` / `src/`.

## Not changed (out of scope, but noted)

`rest/README.md` and `relay/README.md` contain the **same** sync/named-arg REST examples and the `StopAsync/PauseAsync/ResumeAsync` action claim that I corrected in the top-level README. They are inside the DOC-AUDIT-scanned dirs and pass the gate (method names match the surface in their async/sync forms), but the *signatures/casing* shown are stale relative to current source. Fixing those sub-READMEs is outside this task's scope (top-level README only).

---

## Sub-docs audit (follow-up commit on this branch)

Extends this PR with an audit of every **sub-doc** — `relay/docs/*`, `rest/docs/*`, and the `docs/*.md` guides — against the real `src/` surface. The root `README.md` was not touched. **18 files changed** (no `src/`). DOC-AUDIT still passes (`✓ 1036 resolved`, exit 0).

**Docs fully audited (every code block checked against source):** all 5 `relay/docs/*` (getting-started, client-reference, call-methods, events, messaging); all 6 `rest/docs/*` (getting-started, client-reference, calling, compat, fabric, namespaces); `docs/sdk_features.md`, `docs/architecture.md`, `docs/cloud_functions_guide.md`.

**Spot-checked (phantom-pattern sweep + targeted reads, no defects found):** `docs/agent_guide`, `swaig_reference`, `datamap_guide`, `contexts_guide`, `swml_service_guide`, `skills_system`, `api_reference`, `configuration`, `security`, `cli_guide`, `web_service`, `mcp_gateway_reference`, `mcp_integration`, `llm_parameters`, `skills_parameter_schema`, `third_party_skills`. Only package-id and (in architecture/sdk_features) the RELAY/REST example fixes were needed.

**Fixes by area:**
- **RELAY** — `call.PlayAsync(media: ...)` does **not** exist on the Relay `Call`; replaced with the real **synchronous** `PlayTts`/`PlayAudio`/`PlaySilence` and generic `Play(new Dictionary{["play"]=...})` returning a `PlayAction`, then `await action.WaitAsync()`. Same for `Record`/`Collect`/`Detect`/`Tap` (sync starters returning `*Action`). `ConnectAsync(Dictionary)`, `SendDigitsAsync(Dictionary{["digits"]=...})`. Action control `StopAsync/PauseAsync/ResumeAsync` → sync `Stop/Pause/Resume` (only `WaitAsync` is async). `OnMessage` callback is `(Message, Event)` → use `message.Body`/`FromNumber`/`ToNumber`. `Contexts` is `IReadOnlyList<string>`; removed internal-only `SessionId` from the public table.
- **REST** — entire surface is async + `Dictionary`-based: `List()`/`Create(name:)`/`Get(id)`/`Update`/`Delete` → `ListAsync`/`CreateAsync(Dictionary)`/`GetAsync`/`UpdateAsync`/`DeleteAsync` → `Task<Dictionary>`; `SearchAsync(Dictionary)`. `Calling.Dial(from:,to:,url:)` → `DialAsync(Dictionary)`; per-call commands `*Async(callId, Dictionary)`; removed phantom `Connect`/`Answer`/`Hangup`/`Ai`/`SendDigits`/`Enqueue`/`Conference`. `Compat` is a container (`Compat.Calls/Messages.CreateAsync`, not `Compat.Create`); `Fabric.CxmlResources` → real `CxmlScripts`; `Lookup.Get` → `PhoneNumberAsync`; `Project.Get` → `Project.Tokens.CreateAsync`; `Logs`/`Registry` are containers; `SipProfile` is a singleton (`GetAsync`); `Chat`/`Pubsub.Create` → `CreateTokenAsync`; `client.Http.Get/Post` → `GetAsync/PostAsync`. Error type is `SignalWireRestError`.
- **docs/** — `cloud_functions_guide`: phantom `HandleServerlessRequestAsync`/`ConfigureLambda`/`ExecutionMode` replaced with the real `SignalWire.Serverless.Adapter` (`HandleLambda`/`HandleAzure`/`Detect`) and `AgentBase.HandleRequest` for GCF. Package id `SignalWire`/`SignalWire.Agents` → `SignalWire.Sdk` everywhere.
- **DOC_AUDIT_IGNORE.md** — added 3 .NET BCL methods (`ReadToEndAsync`/`ToDictionary`/`WriteAsync`) used by the new realistic GCF handler example (stdlib, not SDK surface; matches existing BCL entries).

**Verified counts/versions against `src/`:** 21 REST namespaces, 5 prefabs, 44 `FunctionResult` actions (the "30+" claim holds), Calling's 37 commands. No Python-only Search System / `.swsearch` / Bedrock / Tutorials references exist in the sub-docs.

**⚠️ Correction to this PR's earlier claim:** the Summary above describes `PlayAsync(media: ...)` as "the real" RELAY method. It is **not** — the Relay `Call` has no `PlayAsync`; the real method is synchronous `Play(...)`/`PlayTts(...)`. DOC-AUDIT only lets `PlayAsync` resolve because `audit_docs.py` normalizes the Python reference surface by adding an `Async` suffix variant (Python's `play` → both `Play` and `PlayAsync`), so the phantom passes the gate. The sub-docs now use the real `Play*`/`WaitAsync` form. The root `README.md` and `examples/RelayAnswerAndWelcome.cs` still carry `call.PlayAsync(media: ...)` (out of scope here, but they would not compile against the current Relay `Call`).

DOC-AUDIT result: `✓ docs/examples reference only known symbols (1036 resolved / 1973 total)`, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

