### PR TITLE
fix(swaig-test): error on no action instead of silently defaulting

### DIFF
--- a/bin/swaig-test
+++ b/bin/swaig-test
@@ -117,7 +117,11 @@ try
     }
     else
     {
-        await DumpSwml(client, options);
+        // Consistent default action: a target with no action flag errors
+        // rather than silently dumping SWML. Matches the cross-port majority
+        // (go/java/ruby/php/perl/rust/cpp/ts all error) and the SWAIG-CLI gate.
+        Console.Error.WriteLine("Error: one of --dump-swml, --list-tools, or --exec is required");
+        Environment.Exit(1);
     }
 }
 catch (HttpRequestException ex)
@@ -198,9 +202,13 @@ static void RunAssemblyMode(CliOptions opts)
         return;
     }
 
-    // Default behaviour: print tool list (the only assembly-mode action
-    // implemented today; --exec/--dump-swml stay URL-only).
-    ListToolsFromInstance(instance, serviceType, opts.Raw);
+    // Consistent default action: assembly mode requires an explicit action
+    // (today only --list-tools is implemented for it). Erroring instead of
+    // silently listing matches the cross-port no-action contract; --exec /
+    // --dump-swml remain URL-only.
+    Console.Error.WriteLine(
+        "Error: --assembly mode requires --list-tools (--exec / --dump-swml are URL-only)");
+    Environment.Exit(1);
 }
 
 static Type ResolveServiceType(Assembly userAsm)


### PR DESCRIPTION
## FIX 3 — consistent default action

`bin/swaig-test` was the cross-port outlier (with TypeScript) that **silently defaulted** to an action when none was given — `--dump-swml` in URL mode and `--list-tools` in `--assembly` mode. Seven of the nine HTTP-model ports (go/java/ruby/php/perl/rust/cpp), plus TypeScript after its companion fix (signalwire/signalwire-typescript#139), instead **error** `one of --dump-swml, --list-tools, or --exec is required` when a target is given without an action flag. This makes .NET match that cross-port majority:

- URL mode with no action flag now errors (was: silent `--dump-swml`).
- `--assembly` mode with no action now errors pointing at `--list-tools` (was: silently listed tools); `--exec` / `--dump-swml` remain URL-only.

`bin/swaig-test` is a standalone `dotnet-script`, not compiled into the SDK or the test assemblies, so this is additive error-handling in an untested-by-design script; the full SDK test suite is unaffected (`run-ci.sh` stays green — verified locally).

## Flag: SWAIG-CLI gate not wired here (yet)

The shared **SWAIG-CLI** gate (porting-sdk `audit_swaig_cli_contract.py`, PR signalwire/porting-sdk#50) is **intentionally not wired into this port's `run-ci.sh`**. The gate invokes the CLI black-box, and the .NET CLI requires the `dotnet-script` global tool, which the gate harness / SDK docker image does not provide. Wiring it would produce an unverifiable / likely-red gate, so it is flagged for follow-up (e.g. add `dotnet-script` to the CI image, or build a thin compiled CLI shim). The genuine default-action drift fix lands here regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)