### PR TITLE
test(relaymock): make event-wait deadlines CI-safe (30s EventTimeout)

### DIFF
--- a/tests/RelayMock/ActionsMockTest.cs
+++ b/tests/RelayMock/ActionsMockTest.cs
@@ -63,7 +63,7 @@ public class ActionsMockTest : IClassFixture<RelayMockServerFixture>
             CallId = callId,
             AutoStates = new() { "created" },
         });
-        await done.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await done.Task.WaitAsync(RelayMockTest.EventTimeout);
 
         // Mark as answered so subsequent actions don't think the call ended.
         captured!.State = "answered";

--- a/tests/RelayMock/ConnectMockTest.cs
+++ b/tests/RelayMock/ConnectMockTest.cs
@@ -259,7 +259,7 @@ public class ConnectMockTest : IClassFixture<RelayMockServerFixture>
 
         // Bypass the SDK and send the malformed connect directly.
         using var ws = new ClientWebSocket();
-        using var connectCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        using var connectCts = new CancellationTokenSource(RelayMockTest.EventTimeout);
         await ws.ConnectAsync(new Uri(_fixture.Harness.WsUrl + "/api/relay/ws"), connectCts.Token);
 
         var requestId = Guid.NewGuid().ToString();
@@ -286,7 +286,7 @@ public class ConnectMockTest : IClassFixture<RelayMockServerFixture>
 
         var buffer = new byte[16 * 1024];
         var assembled = new MemoryStream();
-        using var readCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        using var readCts = new CancellationTokenSource(RelayMockTest.EventTimeout);
         while (true)
         {
             var result = await ws.ReceiveAsync(buffer, readCts.Token);
@@ -317,7 +317,7 @@ public class ConnectMockTest : IClassFixture<RelayMockServerFixture>
 
         // The SDK doesn't have a typed JWT path yet; drive the wire directly.
         using var ws = new ClientWebSocket();
-        using var connectCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        using var connectCts = new CancellationTokenSource(RelayMockTest.EventTimeout);
         await ws.ConnectAsync(new Uri(_fixture.Harness.WsUrl + "/api/relay/ws"), connectCts.Token);
 
         var requestId = Guid.NewGuid().ToString();
@@ -344,7 +344,7 @@ public class ConnectMockTest : IClassFixture<RelayMockServerFixture>
         // Read response (don't care if it succeeded — we're checking the wire).
         var buffer = new byte[16 * 1024];
         var assembled = new MemoryStream();
-        using var readCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        using var readCts = new CancellationTokenSource(RelayMockTest.EventTimeout);
         while (true)
         {
             var result = await ws.ReceiveAsync(buffer, readCts.Token);

--- a/tests/RelayMock/ConvenienceMethodsMockTest.cs
+++ b/tests/RelayMock/ConvenienceMethodsMockTest.cs
@@ -66,7 +66,7 @@ public class ConvenienceMethodsMockTest : IClassFixture<RelayMockServerFixture>
             CallId = callId,
             AutoStates = new() { "created" },
         });
-        await done.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await done.Task.WaitAsync(RelayMockTest.EventTimeout);
         captured!.State = "answered";
         return bound;
     }
@@ -403,7 +403,7 @@ public class ConvenienceMethodsMockTest : IClassFixture<RelayMockServerFixture>
                 CallId = "conv-wait-ans",
                 AutoStates = new() { "created" },
             });
-            await got.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await got.Task.WaitAsync(RelayMockTest.EventTimeout);
             captured!.State = "created";
 
             // Start the waiter BEFORE the answered state lands.
@@ -472,7 +472,7 @@ public class ConvenienceMethodsMockTest : IClassFixture<RelayMockServerFixture>
                 CallId = "conv-wait-end",
                 AutoStates = new() { "created" },
             });
-            await got.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await got.Task.WaitAsync(RelayMockTest.EventTimeout);
             captured!.State = "answered";
 
             var waitTask = captured.WaitForEndingAsync(timeout: 5.0);

--- a/tests/RelayMock/DisposeAsyncMockTest.cs
+++ b/tests/RelayMock/DisposeAsyncMockTest.cs
@@ -61,7 +61,7 @@ public class DisposeAsyncMockTest : IClassFixture<RelayMockServerFixture>
         // The server now lists exactly one NEW live session (our connection).
         // The mock issues the id under "id"; the SDK's SessionId reads a
         // different wire key against this mock, so correlate by set-diff.
-        var newIds = await WaitForNewSession(before, TimeSpan.FromSeconds(5));
+        var newIds = await WaitForNewSession(before, RelayMockTest.EventTimeout);
         Assert.NotEmpty(newIds);
 
         // Dispose — closes the socket and frees the handles.
@@ -73,7 +73,7 @@ public class DisposeAsyncMockTest : IClassFixture<RelayMockServerFixture>
         // async on the server's read loop).
         var gone = await WaitUntil(() =>
             !SessionIds().Overlaps(newIds),
-            TimeSpan.FromSeconds(5));
+            RelayMockTest.EventTimeout);
         Assert.True(gone,
             $"server still lists session(s) [{string.Join(",", newIds)}] after DisposeAsync");
     }
@@ -93,13 +93,13 @@ public class DisposeAsyncMockTest : IClassFixture<RelayMockServerFixture>
         {
             await client.ConnectAsync();
             Assert.True(client.Connected);
-            newIds = await WaitForNewSession(before, TimeSpan.FromSeconds(5));
+            newIds = await WaitForNewSession(before, RelayMockTest.EventTimeout);
             Assert.NotEmpty(newIds);
         } // DisposeAsync invoked here by `await using`.
 
         var gone = await WaitUntil(() =>
             !SessionIds().Overlaps(newIds),
-            TimeSpan.FromSeconds(5));
+            RelayMockTest.EventTimeout);
         Assert.True(gone, "await using did not close the relay session");
     }
 

--- a/tests/RelayMock/EventDispatchMockTest.cs
+++ b/tests/RelayMock/EventDispatchMockTest.cs
@@ -57,7 +57,7 @@ public class EventDispatchMockTest : IClassFixture<RelayMockServerFixture>
             CallId = callId,
             AutoStates = new() { "created" },
         });
-        await done.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await done.Task.WaitAsync(RelayMockTest.EventTimeout);
         captured!.State = "answered";
         return bound;
     }

--- a/tests/RelayMock/InboundCallMockTest.cs
+++ b/tests/RelayMock/InboundCallMockTest.cs
@@ -105,7 +105,7 @@ public class InboundCallMockTest : IClassFixture<RelayMockServerFixture>
                 ToNumber = "+15552220000",
                 AutoStates = new() { "created" },
             });
-            await done.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await done.Task.WaitAsync(RelayMockTest.EventTimeout);
 
             Assert.Single(seen);
             Assert.Equal("c-handler", seen[0].CallId);
@@ -136,7 +136,7 @@ public class InboundCallMockTest : IClassFixture<RelayMockServerFixture>
                 CallId = "c-dir",
                 AutoStates = new() { "created" },
             });
-            await done.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await done.Task.WaitAsync(RelayMockTest.EventTimeout);
 
             Assert.Equal("c-dir", callId);
             Assert.Equal("inbound", direction);
@@ -167,7 +167,7 @@ public class InboundCallMockTest : IClassFixture<RelayMockServerFixture>
                 ToNumber = "+15554445566",
                 AutoStates = new() { "created" },
             });
-            await done.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await done.Task.WaitAsync(RelayMockTest.EventTimeout);
 
             Assert.NotNull(dev);
             var p = dev!["params"] as Dictionary<string, object?>;
@@ -199,7 +199,7 @@ public class InboundCallMockTest : IClassFixture<RelayMockServerFixture>
                 CallId = "c-state",
                 AutoStates = new() { "created" },
             });
-            await done.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await done.Task.WaitAsync(RelayMockTest.EventTimeout);
             Assert.Equal("created", state);
         }
         finally { bound.Client.Disconnect(); }
@@ -228,7 +228,7 @@ public class InboundCallMockTest : IClassFixture<RelayMockServerFixture>
                 CallId = "c-ans",
                 AutoStates = new() { "created" },
             });
-            await answered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await answered.Task.WaitAsync(RelayMockTest.EventTimeout);
             await Task.Delay(150);
 
             var ans = bound.Harness.Journal.Recv("calling.answer");
@@ -260,7 +260,7 @@ public class InboundCallMockTest : IClassFixture<RelayMockServerFixture>
                 CallId = "c-ans-state",
                 AutoStates = new() { "created" },
             });
-            await handlerReturned.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await handlerReturned.Task.WaitAsync(RelayMockTest.EventTimeout);
 
             // Push state(answered).
             bound.Harness.Push(StatePushFrame("c-ans-state", "answered"));
@@ -299,7 +299,7 @@ public class InboundCallMockTest : IClassFixture<RelayMockServerFixture>
                 CallId = "c-hangup",
                 AutoStates = new() { "created" },
             });
-            await done.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await done.Task.WaitAsync(RelayMockTest.EventTimeout);
             await Task.Delay(150);
 
             // Wire shape MUST be calling.end (this caught a typo where we
@@ -332,7 +332,7 @@ public class InboundCallMockTest : IClassFixture<RelayMockServerFixture>
                 CallId = "c-pass",
                 AutoStates = new() { "created" },
             });
-            await done.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await done.Task.WaitAsync(RelayMockTest.EventTimeout);
             await Task.Delay(150);
 
             var passes = bound.Harness.Journal.Recv("calling.pass");
@@ -377,7 +377,7 @@ public class InboundCallMockTest : IClassFixture<RelayMockServerFixture>
                 CallId = "c-seq-2",
                 AutoStates = new() { "created" },
             });
-            await bothDone.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await bothDone.Task.WaitAsync(RelayMockTest.EventTimeout);
 
             Assert.Equal("c-seq-1", seen[0].CallId);
             Assert.Equal("c-seq-2", seen[1].CallId);
@@ -419,7 +419,7 @@ public class InboundCallMockTest : IClassFixture<RelayMockServerFixture>
                 CallId = "cb-2",
                 AutoStates = new() { "created" },
             });
-            await bothDone.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await bothDone.Task.WaitAsync(RelayMockTest.EventTimeout);
 
             // Push answered to ONLY cb-1.
             bound.Harness.Push(StatePushFrame("cb-1", "answered"));
@@ -460,7 +460,7 @@ public class InboundCallMockTest : IClassFixture<RelayMockServerFixture>
                 CallId = "c-scripted",
                 AutoStates = new() { "created" },
             });
-            await handlerDone.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await handlerDone.Task.WaitAsync(RelayMockTest.EventTimeout);
 
             bound.Harness.Push(StatePushFrame("c-scripted", "answered"));
             // Wait for the answered state to land before pushing ended so
@@ -519,7 +519,7 @@ public class InboundCallMockTest : IClassFixture<RelayMockServerFixture>
                 CallId = "c-async",
                 AutoStates = new() { "created" },
             });
-            await fired.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await fired.Task.WaitAsync(RelayMockTest.EventTimeout);
             Assert.Equal("c-async", callId);
         }
         finally { bound.Client.Disconnect(); }
@@ -544,7 +544,7 @@ public class InboundCallMockTest : IClassFixture<RelayMockServerFixture>
                 CallId = "c-raise",
                 AutoStates = new() { "created" },
             });
-            await fired.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await fired.Task.WaitAsync(RelayMockTest.EventTimeout);
             await Task.Delay(150);
 
             // Client is still alive after the throw.
@@ -672,7 +672,7 @@ public class InboundCallMockTest : IClassFixture<RelayMockServerFixture>
                 CallId = "c-wire",
                 AutoStates = new() { "created" },
             });
-            await done.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await done.Task.WaitAsync(RelayMockTest.EventTimeout);
 
             var sends = bound.Harness.Journal.Send().Where(e =>
             {

--- a/tests/RelayMock/MessagingMockTest.cs
+++ b/tests/RelayMock/MessagingMockTest.cs
@@ -342,7 +342,7 @@ public class MessagingMockTest : IClassFixture<RelayMockServerFixture>
                 ["message_state"] = "received",
                 ["tags"] = new List<string> { "incoming" },
             }));
-            var m = await done.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            var m = await done.Task.WaitAsync(RelayMockTest.EventTimeout);
             Assert.Equal("in-msg-1", m.MessageId);
             Assert.Equal("inbound", m.Direction);
             Assert.Equal("+15551110000", m.FromNumber);

--- a/tests/RelayMockTest.cs
+++ b/tests/RelayMockTest.cs
@@ -36,6 +36,18 @@ public static class RelayMockTest
     private static readonly TimeSpan StartupTimeout = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan HttpTimeout = TimeSpan.FromSeconds(30);
 
+    /// <summary>
+    /// CI-safe budget for awaiting a single mock&lt;-&gt;client event round-trip
+    /// (an inbound call dispatched to <c>OnCall</c>, a pushed RELAY event reaching
+    /// a handler, or the mock observing a session open/close). Matches
+    /// <see cref="StartupTimeout"/>'s 30s: the round-trip completes in ~200ms when
+    /// healthy, so 30s only ever trips on a genuine hang — never on the slower,
+    /// contended GitHub CI runner (net10 + docker + parallel xUnit load). A
+    /// too-tight 5s deadline here was the latent cause of the intermittent
+    /// <c>TimeoutException</c> failures in the cross-port CI's dotnet leg.
+    /// </summary>
+    public static readonly TimeSpan EventTimeout = TimeSpan.FromSeconds(30);
+
     private static readonly object StateLock = new();
     private static Harness? _sharedHarness;
     private static Exception? _startupFailure;


### PR DESCRIPTION
## Root cause

The porting-sdk cross-port CI's **dotnet leg** intermittently failed on **net10.0** with a `System.TimeoutException` at the `AnsweredInboundCall` helper (`tests/RelayMock/ConvenienceMethodsMockTest.cs:69`), on `await done.Task.WaitAsync(TimeSpan.FromSeconds(5))`.

This is **not a product bug and not a clean flake** — verified by running the path:

- The single failing test passes **3/3 in ~220 ms** locally.
- The full `Category=RelayMock` suite passes **118/118 in ~4 s** locally.
- The inbound-call event round-trip is healthy and fast; when healthy it completes in ~200 ms.

The actual cause is **timeout-tightness under the slower, contended GitHub CI runner** (net10 + docker + parallel xUnit load). A hardcoded **5-second** deadline on an async event round-trip occasionally trips on CI contention even though the operation itself is fast. This is the #34/#68 RelayMock fixture family (connection reuse already fixed); this was a separate latent issue — scattered too-tight 5s event-wait deadlines.

## Fix (test-only — no product code, no SDK behavior change)

1. Added a shared, public CI-safe budget in `tests/RelayMockTest.cs`:
   ```csharp
   public static readonly TimeSpan EventTimeout = TimeSpan.FromSeconds(30);
   ```
   It matches the existing `StartupTimeout`/`HttpTimeout` 30s budget. Since a healthy round-trip is ~200 ms, 30s only ever trips on a genuine hang — never on CI contention.

2. Replaced the **28** event-wait deadlines that bound a mock↔client event round-trip (`await X.Task.WaitAsync(...)`, `CancellationTokenSource(...)` on a raw ws connect/read, `WaitForNewSession`/`WaitUntil` poll budgets) with `RelayMockTest.EventTimeout`, across:

   | File | Sites |
   |---|---|
   | `InboundCallMockTest.cs` | 14 |
   | `ConnectMockTest.cs` | 4 |
   | `DisposeAsyncMockTest.cs` | 4 |
   | `ConvenienceMethodsMockTest.cs` | 3 |
   | `ActionsMockTest.cs` | 1 |
   | `EventDispatchMockTest.cs` | 1 |
   | `MessagingMockTest.cs` | 1 |

## Discriminated, not blanket

Only timeouts bounding an event/round-trip **wait** were bumped. Deliberately **not** changed:

- **`tests/SkillsTests.cs:833,876`** — `Assert.True(sw.Elapsed < TimeSpan.FromSeconds(5), ...)` are latency *assertions* ("this completed fast"), the opposite of a wait deadline. Bumping would defeat the assertion. Left as-is (and out of scope — not a RelayMock file).
- **`ConvenienceMethodsMockTest.cs` `WaitForAnsweredAsync(timeout: 5.0)` etc.** — these are `double` args to the SDK's own `WaitForXAsync` product API, paired with `Assert.False(waitTask.IsCompleted)` non-completion checks. They exercise product behavior; bumping would change test semantics. Not matched by the change (they aren't `TimeSpan.FromSeconds(5)`).

`DisposeAsyncMockTest.cs`'s 5s waits **were** bumped: they are `WaitForNewSession`/`WaitUntil` poll budgets for the mock observing a session open/close — an async round-trip on the server's read loop, the same flaky class — not "dispose completes quickly" assertions.

No `FromSeconds(5)` event-waits remain in the RelayMock test directory (verified by grep).

## Verification

Full `scripts/run-ci.sh` run: **CI PASS** — all 13 gates green, including:
- `TEST` (dotnet test net8.0/net9.0/net10.0, sequential, against the spawned mock_relay/mock_signalwire)
- `FMT` (dotnet format whitespace)
- `LINT` (analyzers, warnings-as-errors)

Mocks were spawned on free ports via the gate's own lifecycle and reaped on exit (no zombies left behind).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
