### PR TITLE
ci(swaig-test): wire shared SWAIG-CLI mini-contract gate (+ fix dotnet-script compile)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ TestResults/
 scripts/__pycache__/
 core
 core.*
+# dotnet-script tool provisioned by the SWAIG-CLI gate (scripts/run-ci.sh)
+.dotnet-tools/

--- a/bin/swaig-test
+++ b/bin/swaig-test
@@ -34,6 +34,8 @@
 // resolver below to make sure of that), and we reach the SDK types
 // purely via reflection.
 
+#nullable enable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -90,7 +92,11 @@ if (!options.HasUrl)
     Environment.Exit(1);
 }
 
-using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+// NB: a plain `var` (not `using var`): a top-level `using var` declaration is a
+// directive-vs-declaration ambiguity under dotnet-script's script compilation
+// (CS1002). The process exits immediately after the action runs, so the OS
+// reclaims the connection — explicit disposal buys nothing for a one-shot CLI.
+var client = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
 
 // Apply auth if extracted from URL
 if (options.AuthUser is not null && options.AuthPassword is not null)
@@ -501,6 +507,18 @@ static CliOptions ParseArgs(string[] args)
             case "--help":
             case "-h":
                 opts.Help = true;
+                break;
+            default:
+                // Reject unknown options loudly rather than silently ignoring
+                // them. A silently-swallowed flag (e.g. --simulate-serverless,
+                // which this port does not implement) would let a caller think
+                // it took effect. The cross-port swaig-test contract requires an
+                // unknown/unimplemented option to error, not no-op.
+                if (args[i].StartsWith("-"))
+                {
+                    Console.Error.WriteLine($"Error: unknown option '{args[i]}'");
+                    Environment.Exit(2);
+                }
                 break;
         }
     }

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -333,6 +333,34 @@ lint_gate() {
     $dn build src/SignalWire/SignalWire.csproj -c Release --no-incremental
 }
 
+# SWAIG-CLI gate: lightweight shared swaig-test mini-contract (NOT python parity;
+# python's in-process simulator surface is reference-only). Black-box: invokes
+# `bin/swaig-test --help` + golden invocations and asserts the shared verbs are
+# documented and a target-but-no-action invocation errors (the cross-port
+# default). bin/swaig-test is a dotnet-script, so we run it via `dotnet script`.
+# dotnet's swaig-test is an HTTP-probe model (--url, like the 7 wire ports), so
+# we pass --require-url-model. It does NOT implement --simulate-serverless, so
+# the no-serverless clause asserts the flag is rejected as an unknown option
+# (the bin/swaig-test default: case errors on any unknown -flag).
+swaig_cli_gate() {
+    local dn
+    dn="$(dotnet_cmd)"
+    # dotnet-script is the runner for bin/swaig-test. Provision it as a tool-path
+    # tool (idempotent: install is a no-op / fails-harmlessly if already present),
+    # then put it on PATH for the duration of the gate.
+    local toolroot="$PORT_ROOT/.dotnet-tools"
+    if [ ! -x "$toolroot/dotnet-script" ]; then
+        $dn tool install dotnet-script --tool-path "$toolroot" >/dev/null 2>&1 || true
+    fi
+    PATH="$toolroot:$PATH" \
+    python3 "$PORTING_SDK_DIR/scripts/audit_swaig_cli_contract.py" \
+        --port dotnet \
+        --cmd "dotnet script $PORT_ROOT/bin/swaig-test --" \
+        --require-url-model \
+        --default-action-argv='--url|http://user:pass@127.0.0.1:1/' \
+        --no-serverless-argv='--url|http://user:pass@127.0.0.1:1/|--simulate-serverless|lambda|--list-tools'
+}
+
 cd "$PORT_ROOT"
 
 echo "==> running CI gates for $PORT_NAME (porting-sdk at $PORTING_SDK_DIR)"
@@ -514,6 +542,12 @@ run_gate "SKILL-CONTRACT" "diff_skill_contracts vs python reference" \
     python3 "$PORTING_SDK_DIR/scripts/diff_skill_contracts.py" \
         --dump-cmd "bash $PORT_ROOT/scripts/emit-skills.sh" \
         --port-repo "$PORT_ROOT"
+
+# Gate 12: SWAIG-CLI — lightweight shared swaig-test mini-contract (verbs are
+# documented in --help, a target-but-no-action invocation errors, and an
+# unimplemented --simulate-serverless is rejected as an unknown option).
+run_gate "SWAIG-CLI" "swaig-test shared mini-contract (verbs/serverless-reject/default-action)" \
+    swaig_cli_gate
 
 if [ -z "$FAILED_GATES" ]; then
     echo "==> CI PASS"


### PR DESCRIPTION
## What

dotnet was the **one applicable port missing the shared SWAIG-CLI gate** (Gate 12) that the other 8 wire ports (ts/go/java/php/ruby/perl/rust/cpp) already have. Wiring it here surfaced two **real, pre-existing defects** that made `bin/swaig-test` non-functional under `dotnet-script` 2.0.1 — the CLI did not compile at all on `main`.

## The drift this caught

1. **`CS8632`** — the script uses `string?` nullable annotations with no `#nullable` context.
2. **`CS1002` + cascading `CS0103`** — a top-level `using var client = ...` declaration, which dotnet-script's script compilation reads as a `using` *directive* (not a declaration), breaking the rest of the file (`'client' does not exist`).
3. **silent flag swallow** — the arg-parse `switch` had no `default:` arm, so `--simulate-serverless` (which this port does not implement) was silently ignored instead of rejected. That's the exact silent-fallback class the cross-port swaig contract exists to catch.

## Fixes

- `#nullable enable` at the top of `bin/swaig-test`.
- `using var client` → `var client` (one-shot CLI: the process exits right after the action runs, so the OS reclaims the socket — explicit disposal is moot).
- `default:` arm errors (exit 2) on any unknown `-flag`, while still letting valid verbs + their arguments through.
- **Gate 12 (SWAIG-CLI)** in `scripts/run-ci.sh`: provisions `dotnet-script` to a gitignored `.dotnet-tools/` tool-path and runs `porting-sdk/scripts/audit_swaig_cli_contract.py` against `dotnet script bin/swaig-test --` with `--require-url-model` (HTTP-probe model, like the other 7 wire ports).

## Verified locally

```
SWAIG-CLI mini-contract — port: dotnet
  [PASS] shared-verbs-documented
  [PASS] default-action-errors-when-no-action
  [PASS] serverless-flag-rejected-when-unsupported
  => OK
```

Closes the last hole in the swaig-test gate rollout (all 9 applicable ports now wired; python is the reference in-process simulator and is exempt by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)