### PR TITLE
fix(swml): ai-verb prompt must be an object {text:} — bare string fatals the call

### DIFF
--- a/src/SignalWire/SWML/SWMLBuilder.cs
+++ b/src/SignalWire/SWML/SWMLBuilder.cs
@@ -54,15 +54,19 @@ public class SWMLBuilder
         Dictionary<string, object>? extraParams = null)
     {
         var config = new Dictionary<string, object>();
+        // The SWML ``ai`` verb requires ``prompt`` to be an OBJECT — {"text": ...} or
+        // {"pom": [...]}; a bare string is a fatal error in the AI engine (mod_openai
+        // app_config.c: ``!cJSON_IsObject(prompt)`` fires calling.error and aborts the call),
+        // so wrap accordingly. ``post_prompt`` is the same object contract.
         if (!string.IsNullOrEmpty(promptText))
         {
-            config["prompt"] = promptText;
+            config["prompt"] = new Dictionary<string, object> { ["text"] = promptText };
         }
         else if (promptPom is not null)
         {
             config["prompt"] = new Dictionary<string, object> { ["pom"] = promptPom };
         }
-        if (!string.IsNullOrEmpty(postPrompt)) config["post_prompt"] = postPrompt;
+        if (!string.IsNullOrEmpty(postPrompt)) config["post_prompt"] = new Dictionary<string, object> { ["text"] = postPrompt };
         if (!string.IsNullOrEmpty(postPromptUrl)) config["post_prompt_url"] = postPromptUrl;
         if (swaig is not null) config["SWAIG"] = swaig;
         if (extraParams is not null)

--- a/tests/StructuralParityTests.cs
+++ b/tests/StructuralParityTests.cs
@@ -771,7 +771,10 @@ public class StructuralParityTests
         var main = sections["main"];
         var ai = main.First(v => v.ContainsKey("ai"));
         var config = (Dictionary<string, object>)ai["ai"]!;
-        Assert.Equal("You are helpful", config["prompt"]);
+        // The ai-verb prompt is an OBJECT {"text": ...} (a bare string fatals the call in the
+        // AI engine); see SWMLBuilder.Ai. Matches the Python/Go ports.
+        var prompt = (Dictionary<string, object>)config["prompt"];
+        Assert.Equal("You are helpful", prompt["text"]);
     }
 
     [Fact]


### PR DESCRIPTION
## What

`SWMLBuilder.Ai()` emitted the ai-verb `prompt` (and `post_prompt`) as a **bare string**:
```csharp
config["prompt"] = promptText;        // bare string
config["post_prompt"] = postPrompt;   // bare string
```

The SWML `ai` verb requires `prompt`/`post_prompt` to be an **object** — `{"text": "…"}` or `{"pom": […]}`. A bare string is a **fatal error** in the AI engine: mod_openai `app_config.c` does `if (!cJSON_IsObject(prompt))` → fires a `calling.error` relay event and **aborts the call** (verified against the mod_infrastructure + mod_openai source). The `pom` branch already wrapped correctly; `text`/`post_prompt` now do too.

## Why it was latent

The production `AgentBase` render path builds the wrapped `{"prompt": {"text": …}}` object itself and bypasses `SWMLBuilder.Ai`, so live agents work. Only direct `SWMLBuilder.Ai()` callers hit the bug.

## Cross-port

This is a known cross-port bug class (flagged in `porting-sdk/GLOBAL_MEMORY.md`):
- **Go** — already fixed (PR #107).
- **Python** — fixed (companion change).
- **.NET** — this PR.

⚠️ The **Contexts/Steps** `prompt` is the **opposite** contract — the engine reads it as a bare string (`step_management.c: cJSON_GetObjectCstr(context, "prompt")`), so the Contexts bare-string emit is correct and is **unchanged** here.

## Tests

- `StructuralParityTests.SWMLBuilder_AiVerb_PromptText` updated to assert the object form.
- SWML/parity suite: **218 pass, 0 fail**. (The unrelated RestMock failures require a running mock_signalwire server and are pre-existing on `main`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)